### PR TITLE
highlighting fix

### DIFF
--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -56,10 +56,10 @@ repository:
       - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[(\{])'
         name: entity.name.union.zig
 
-      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:struct)\s*[(\{])'
         name: entity.name.struct.zig
 
-      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum)\s*[(\{])'
         name: entity.name.enum.zig
 
       - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[(\{])'
@@ -219,20 +219,6 @@ repository:
       - name: punctuation.terminator.zig
         match: ';'
 
-      # TODO match variable names?
-      # - match: '(?:([a-zA-Z_]\w*|@\".+\")|(?<=\)))(?:(\.)|(,)|(;))'
-      #   captures:
-      #     '1':
-      #       name: variable.other.zig
-      #     '2':
-      #       name: punctuation.accessor.zig
-      #     '3':
-      #       name: punctuation.separator.zig
-      #     '4':
-      #       name: punctuation.terminator.zig
-      #     '5':
-      #       name: variable.other.zig
-
       - match: '(\()'
         name: punctuation.section.parens.begin.zig
 
@@ -323,4 +309,3 @@ repository:
       - include: '#block'
       - include: '#function_def'
       - include: '#function_call'
-

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -211,19 +211,6 @@ repository:
       - name: storage.type.error.zig
         match: '\berror\b'
 
-      # - match: '(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
-      #   captures:
-      #     '1':
-      #       name: keyword.operator.other.zig
-      #     '2':
-      #       name: storage.modifier.zig
-      #     '3':
-      #       name: keyword.operator.other.zig
-      #     '4':
-      #       name: keyword.operator.other.zig
-      #     '5':
-      #       name: storage.type.zig
-
   punctuation:
     patterns:
       - name: punctuation.separator.zig

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -9,46 +9,6 @@ patterns:
   - include: '#main'
 
 repository:
-  field_decl:
-    begin: '([a-zA-Z_]\w*|@\".+\")\s*(:)\s*'
-    beginCaptures:
-      '1':
-        name: variable.other.member.zig
-      '2':
-        name: punctuation.terminator.zig
-
-    contentName: storage.type.zig
-
-    end: '(?:(,)|(?:\n|\r))'
-    endCaptures:
-      '1':
-        name: punctuation.separator.zig
-
-    patterns:
-      - include: '#main'
-
-  param_list:
-    begin: '(comptime|noalias)?\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*'
-    beginCaptures:
-      '1':
-        name: storage.modifier.zig
-      '2':
-        name: variable.parameter.zig
-      '3':
-        name: punctuation.terminator.zig
-    
-    contentName: storage.type.zig
-
-    end: '(?:(,)|(?:\)))'
-    endCaptures:
-      '1':
-        name: punctuation.separator.zig
-      '2':
-        name: punctuation.section.parens.end.zig
-
-    patterns:
-      - include: '#main'
-
   character_escapes:
     patterns:
       - name: constant.character.escape.newline.zig
@@ -74,99 +34,17 @@ repository:
 
   container_decl:
     patterns:
-      - begin: '(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(packed|extern)?\b\s*(union\b)(?:(\()([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(\)))?\s*({)'
-        beginCaptures:
-          '1':
-            name: entity.name.union.zig
-          '2':
-            name: storage.modifier.zig
-          '3':
-            name: storage.type.union.zig
-          '4':
-            name: punctuation.section.parens.begin.zig
-          '5':
-            name: storage.type.zig
-          '6':
-            name: punctuation.section.parens.end.zig
-          '7':
-            name: punctuation.section.braces.begin.zig
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[({])'
+        name: entity.name.union.zig
 
-        contentName: meta.union
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])'
+        name: entity.name.struct.zig
 
-        end: '(})'
-        endCaptures:
-          '1':
-            name: punctuation.section.braces.end.zig
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])'
+        name: entity.name.enum.zig
 
-        patterns:
-          - include: '#main'
-
-      - begin: '(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(packed|extern)?\b\s*(struct)\s*({)'
-        beginCaptures:
-          '1':
-            name: entity.name.struct.zig
-          '2':
-            name: storage.modifier.zig
-          '3':
-            name: storage.type.struct.zig
-          '4':
-            name: punctuation.section.braces.begin.zig
-
-        contentName: meta.struct.zig
-
-        end: '(})'
-        endCaptures:
-          '1':
-            name: punctuation.section.braces.end.zig
-
-        patterns:
-          - include: '#main'
-
-      - begin: '(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(extern)?\b\s*(enum\b)(?:(\()([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(\)))?\s*({)'
-        beginCaptures:
-          '1':
-            name: entity.name.enum.zig
-          '2':
-            name: storage.modifier.zig
-          '3':
-            name: storage.type.enum.zig
-          '4':
-            name: punctuation.section.parens.begin.zig
-          '5':
-            name: storage.type.zig
-          '6':
-            name: punctuation.section.parens.end.zig
-          '7':
-            name: punctuation.section.braces.begin.zig
-
-        contentName: meta.enum.zig
-
-        end: '(})'
-        endCaptures:
-          '1':
-            name: punctuation.section.braces.end.zig
-
-        patterns:
-          - include: '#main'
-
-      - begin: '(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(error)\b\s*({)'
-        beginCaptures:
-          '1':
-            name: entity.name.error.zig
-          '2':
-            name: storage.type.error.zig
-          '3':
-            name: punctuation.section.braces.begin.zig
-
-        contentName: meta.error.zig
-
-        end: '(})'
-        endCaptures:
-          '1':
-            name: punctuation.section.braces.end.zig
-
-        patterns:
-          - include: '#main'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[({])'
+        name: entity.name.error.zig
 
       - match: '\b(error)(\.)([a-zA-Z_]\w*|@\".+\")'
         captures:
@@ -244,7 +122,7 @@ repository:
       match: '\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\b'
 
     - name: keyword.control.async.zig
-      match: '\b(async|await|suspend|resume|cancel)\b'
+      match: '\b(noasync|async|await|suspend|resume|cancel)\b'
 
     - name: keyword.control.conditional.zig
       match: '\b(if|else|switch|try|catch|orelse)\b'
@@ -253,10 +131,7 @@ repository:
       match: '(?<!\w)(@import|@cImport|@cInclude)\b'
 
     - name: keyword.other.usingnamespace.zig
-      match: '\busingnamespace\b'
-
-    - name: keyword.other.test.zig
-      match: '\btest\b'
+      match: '\b(usingnamespace|use)\b'
 
   operators:
     patterns:
@@ -273,13 +148,13 @@ repository:
         match: '((?:(?:\+|-|\*)\%?|/|%|<<|>>|&|\|(?=[^\|])|\^)?=)'
 
       - name: keyword.operator.arithmetic.zig
-        match: '((?:\+|-|(?<=\w)\s*\*)\%?|/(?!/)|%)'
+        match: '((?:\+|-|(?<=[a-zA-Z_]|@\")\s*\*)\%?|/(?!/)|%)'
 
       - name: keyword.operator.bitwise.zig
-        match: '(<<|>>|&(?=\W)|\|(?=[^\|])|\^|~)'
+        match: '(<<|>>|&(?=[a-zA-Z_]|@\")|\|(?=[^\|])|\^|~)'
 
       - name: keyword.operator.other.zig
-        match: '(\+\+|\*\*|->|\.\?|\.\*|&(?=\w)|\?|\|\||\.\.|\.\.\.)'
+        match: '(\+\+|\*\*|->|\.\?|\.\*|&(?=[a-zA-Z_]|@\")|\?|\|\||\.{2,3})'
   
   support:
     name: support.function.zig
@@ -299,18 +174,36 @@ repository:
       - name: storage.type.c_compat.zig
         match: '\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\b'
 
-      # - match: '(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
-      #   captures:
-      #     '1':
-      #       name: keyword.operator.other.zig
-      #     '2':
-      #       name: storage.modifier.zig
-      #     '3':
-      #       name: keyword.operator.other.zig
-      #     '4':
-      #       name: keyword.operator.other.zig
-      #     '5':
-      #       name: storage.type.zig
+      - name: storage.type.function.zig
+        match: '\bfn\b'
+
+      - name: storage.type.test.zig
+        match: '\btest\b'
+
+      - name: storage.type.struct.zig
+        match: '\bstruct\b'
+
+      - name: storage.type.enum.zig
+        match: '\benum\b'
+
+      - name: storage.type.union.zig
+        match: '\bunion\b'
+
+      - name: storage.type.error.zig
+        match: '\berror\b'
+
+      - match: '(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
+        captures:
+          '1':
+            name: keyword.operator.other.zig
+          '2':
+            name: storage.modifier.zig
+          '3':
+            name: keyword.operator.other.zig
+          '4':
+            name: keyword.operator.other.zig
+          '5':
+            name: storage.type.zig
 
   punctuation:
     patterns:
@@ -350,26 +243,14 @@ repository:
           - include: '#main'
 
   label:
-    patterns:
-      - name: entity.name.label.zig
-        match: '(?<!\w):([a-zA-Z_]\w*|@\".+\")'
-
-      - begin: '([a-zA-Z_]\w*|@\".+\"):\s*(?:({)|(while|for))'
-        beginCaptures:
-          '1':
-            name: entity.name.label.zig
-          '2':
-            name: punctuation.section.braces.begin.zig
-          '3':
-            name: keyword.control.zig
-
-        end: '(})'
-        endCaptures:
-          '1':
-            name: punctuation.section.braces.end.zig
-
-        patterns:
-          - include: '#main'
+    match: '\b(break|continue)\s*:\s*([a-zA-Z_]\w*|@\".+\")\b|\b(?!\d)([a-zA-Z_]\w*|@\".+\")\b(?=\s*:\s*(?:\{|while\b))'
+    captures:
+      '1':
+        name: keyword.control.zig
+      '2':
+        name: entity.name.label.zig
+      '3':
+        name: entity.name.label.zig
 
   block:
     begin: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?\s*(\{)'
@@ -389,92 +270,32 @@ repository:
     patterns:
       - include: '#main'
 
-  func_call:
-    begin: '([a-zA-Z_]\w*|@\".+\")(\()'
-    beginCaptures:
-      '1':
-        name: variable.function.zig
-      '2':
-        name: punctuation.section.parens.begin.zig
+  function_def:
+    name: entity.name.function
+    match: '(?<=fn)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()'
 
-    contentName: meta.function-call.zig
-
-    end: '(\))'
-    endCaptures:
-      '1':
-        name: punctuation.section.parens.end.zig
-
-    patterns:
-      - include: '#main'
-      - match: '(?:(,)|(?:\)))'
-        captures:
-          '1':
-            name: punctuation.separator.zig
-          '2':
-            name: punctuation.section.parens.end.zig
+  function:
+    name: variable.function.zig
+    match: '(?<!fn)\b([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()'
 
   main:
     patterns:
-      # function pointer types
-      - begin: '\b(fn)(\()'
-        beginCaptures:
-          '1':
-            name: storage.type.function.zig
-          '2':
-            name: punctuation.section.parens.begin.zig
-
-        contentName: meta.parameters.zig
-
-        end: '(\))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
-        endCaptures:
-          '1':
-            name: punctuation.section.parens.end.zig
-          '2':
-            name: storage.type.zig
-
-        patterns:
-          - match: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(,)?'
-            captures:
-              '1':
-                name: storage.type.zig
-              '2':
-                name: punctuation.separator.zig
-
-      # function decalaration
-      - begin: '\b(fn)\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(\()'
-        beginCaptures:
-          '1':
-            name: storage.type.function.zig
-          '2':
-            name: entity.name.function.zig
-          '3':
-            name: punctuation.section.parens.begin.zig
-
-        contentName: meta.function.parameters.zig
-
-        end: '(?<=\))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
-        endCaptures:
-          '1':
-            name: storage.type.zig
-
-        patterns:
-          - include: '#param_list'
-
       # variable/constant declaration
-      - match: '\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(=)'
-        captures:
-          '1':
-            name: storage.modifier.zig
-          '2':
-            name: variable.other.zig
-          '3':
-            name: punctuation.terminator.zig
-          '4':
-            name: storage.type.zig
-          '5':
-            name: keyword.operator.assignment.zig
+      # - match: '\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(=)'
+      #   captures:
+      #     '1':
+      #       name: storage.modifier.zig
+      #     '2':
+      #       name: variable.other.zig
+      #     '3':
+      #       name: punctuation.terminator.zig
+      #     '4':
+      #       name: storage.type.zig
+      #     '5':
+      #       name: keyword.operator.assignment.zig
 
-      - include: '#func_call'
+      - include: '#function_def'
+      - include: '#function'
       - include: '#label'
       - include: '#punctuation'
       - include: '#storage_modifier'

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -36,13 +36,14 @@ repository:
       '2':
         name: punctuation.separator.zig
 
-    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|(?=\)))'
-
+    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")?\s*(?:(,)|(\)))'
     endCaptures:
       '1':
         name: storage.type.zig
       '2':
         name: punctuation.separator.zig
+      '3':
+        name: punctuation.section.parens.end.zig
 
     patterns:
       - include: '#main'
@@ -263,8 +264,6 @@ repository:
       '2':
         name: punctuation.section.braces.begin.zig
 
-    contentName: meta.block.zig
-
     end: '(\})'
     endCaptures:
       '1':
@@ -281,16 +280,17 @@ repository:
       '2':
         name: punctuation.section.parens.begin.zig
 
-    contentName: meta.function.parameters.zig
-
-    end: '(\))'
+    end: '(?<=\))([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
     endCaptures:
       '1':
-        name: punctuation.section.parens.begin.zig
+        name: storage.type.zig
 
     patterns:
       - include: '#param_list'
       - include: '#main'
+
+      - match: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+        name: storage.type.zig
 
   function_call:
     name: variable.function.zig
@@ -304,16 +304,19 @@ repository:
       '2':
         name: punctuation.section.parens.begin.zig
 
-    contentName: meta.parameters.zig
+    contentName: meta.function.parameters.zig
 
-    end: '(\))'
+    end: '(?<=\))\s*([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
     endCaptures:
       '1':
-        name: punctuation.section.parens.end.zig
+        name: storage.type.zig
 
     patterns:
       - include: '#param_list'
       - include: '#main'
+
+      - match: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+        name: storage.type.zig
 
   var_decl:
     begin: '\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)'
@@ -354,5 +357,5 @@ repository:
       - include: '#support'
       - include: '#field_decl'
       - include: '#block'
-      - include: '#function_call'
       - include: '#function_def'
+      - include: '#function_call'

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -174,7 +174,7 @@ repository:
       match: '(?<!\w)(@import|@cImport|@cInclude)\b'
 
     - name: keyword.other.usingnamespace.zig
-      match: '\b(usingnamespace|use)\b'
+      match: '\b(usingnamespace)\b'
 
   operators:
     patterns:
@@ -206,7 +206,7 @@ repository:
   storage:
     patterns:
       - name: storage.type.zig
-        match: '\b(bool|void|noreturn|type|anyerror|anyframe|promise)\b'
+        match: '\b(bool|void|noreturn|type|anyerror|anyframe)\b'
 
       - name: storage.type.integer.zig
         match: '\b(?<!\.)([iu][0-9]\d*|[iu]size|comptime_int)\b'

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -28,24 +28,21 @@ repository:
       - name: constant.character.escape.hexidecimal.zig
         match: \\u\{[a-fA-F0-9]{1,6}\}
 
-  param_list:
-    begin: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*'
+  param_field:
+    begin: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)\s*'
     beginCaptures:
       '1':
-        name: storage.modifier.zig
-      '2':
         name: variable.parameter.zig
-      '3':
-        name: punctuation.terminator.zig
+      '2':
+        name: punctuation.separator.zig
 
-    contentName: storage.type.zig
+    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|(?=\)))'
 
-    end: '(?:(,)|(?:\)))'
     endCaptures:
       '1':
-        name: punctuation.separator.zig
+        name: storage.type.zig
       '2':
-        name: punctuation.section.parens.end.zig
+        name: punctuation.separator.zig
 
     patterns:
       - include: '#main'
@@ -56,16 +53,16 @@ repository:
 
   container_decl:
     patterns:
-      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[({])'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[(\{])'
         name: entity.name.union.zig
 
-      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])'
         name: entity.name.struct.zig
 
-      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])'
         name: entity.name.enum.zig
 
-      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[({])'
+      - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[(\{])'
         name: entity.name.error.zig
 
       - match: '\b(error)(\.)([a-zA-Z_]\w*|@\".+\")'
@@ -170,7 +167,7 @@ repository:
         match: '((?:(?:\+|-|\*)\%?|/|%|<<|>>|&|\|(?=[^\|])|\^)?=)'
 
       - name: keyword.operator.arithmetic.zig
-        match: '((?:\+|-|(?<=[a-zA-Z_]|@\")\s*\*)\%?|/(?!/)|%)'
+        match: '((?:\+|-|\*)\%?|/(?!/)|%)'
 
       - name: keyword.operator.bitwise.zig
         match: '(<<|>>|&(?=[a-zA-Z_]|@\")|\|(?=[^\|])|\^|~)'
@@ -214,18 +211,18 @@ repository:
       - name: storage.type.error.zig
         match: '\berror\b'
 
-      - match: '(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
-        captures:
-          '1':
-            name: keyword.operator.other.zig
-          '2':
-            name: storage.modifier.zig
-          '3':
-            name: keyword.operator.other.zig
-          '4':
-            name: keyword.operator.other.zig
-          '5':
-            name: storage.type.zig
+      # - match: '(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?'
+      #   captures:
+      #     '1':
+      #       name: keyword.operator.other.zig
+      #     '2':
+      #       name: storage.modifier.zig
+      #     '3':
+      #       name: keyword.operator.other.zig
+      #     '4':
+      #       name: keyword.operator.other.zig
+      #     '5':
+      #       name: storage.type.zig
 
   punctuation:
     patterns:
@@ -284,10 +281,25 @@ repository:
       - include: '#main'
 
   function_def:
-    name: entity.name.function
-    match: '(?<=fn)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()'
+    begin: '(?<=fn)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(\()'
+    beginCaptures:
+      '1':
+        name: entity.name.function
+      '2':
+        name: punctuation.section.parens.begin.zig
 
-  function:
+    contentName: meta.function.parameters.zig
+
+    end: '(\))'
+    endCaptures:
+      '1':
+        name: punctuation.section.parens.begin.zig
+
+    patterns:
+      - include: '#param_field'
+      - include: '#main'
+
+  function_call:
     name: variable.function.zig
     match: '(?<!fn)\b([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()'
 
@@ -308,8 +320,7 @@ repository:
       #       name: keyword.operator.assignment.zig
 
       # - include: '#param_list'
-      - include: '#function_def'
-      - include: '#function'
+      
       - include: '#label'
       - include: '#punctuation'
       - include: '#storage_modifier'
@@ -323,4 +334,6 @@ repository:
       - include: '#support'
       - include: '#field_decl'
       - include: '#block'
+      - include: '#function_def'
+      - include: '#function_call'
 

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -28,7 +28,7 @@ repository:
       - name: constant.character.escape.hexidecimal.zig
         match: \\u\{[a-fA-F0-9]{1,6}\}
 
-  param_field:
+  param_list:
     begin: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)\s*'
     beginCaptures:
       '1':
@@ -43,6 +43,26 @@ repository:
         name: storage.type.zig
       '2':
         name: punctuation.separator.zig
+
+    patterns:
+      - include: '#main'
+
+  field_decl:
+    begin: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)\s*'
+    beginCaptures:
+      '1':
+        name: variable.other.member.zig
+      '2':
+        name: punctuation.separator.zig
+
+    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|\s*(=)\s*|(?=\n|\r))'
+    endCaptures:
+      '1':
+        name: storage.type.zig
+      '2':
+        name: punctuation.separator.zig
+      '3':
+        name: keyword.operator.assignment.zig
 
     patterns:
       - include: '#main'
@@ -269,12 +289,31 @@ repository:
         name: punctuation.section.parens.begin.zig
 
     patterns:
-      - include: '#param_field'
+      - include: '#param_list'
       - include: '#main'
 
   function_call:
     name: variable.function.zig
     match: '(?<!fn)\b([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()'
+
+  function_type:
+    begin: '\b(fn)\s*(\()'
+    beginCaptures:
+      '1':
+        name: storage.type.function.zig
+      '2':
+        name: punctuation.section.parens.begin.zig
+
+    contentName: meta.parameters.zig
+
+    end: '(\))'
+    endCaptures:
+      '1':
+        name: punctuation.section.parens.end.zig
+
+    patterns:
+      - include: '#param_list'
+      - include: '#main'
 
   var_decl:
     begin: '\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)'
@@ -286,18 +325,21 @@ repository:
       '3':
         name: punctuation.separator.zig
 
-    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(=)'
+    end: '\s*(=)'
     endCaptures:
       '1':
-        name: storage.type.zig
-      '2':
         name: keyword.operator.assignment.zig
 
     patterns:
       - include: '#main'
 
+      - match: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+        name: storage.type.zig
+
   main:
     patterns:
+      - include: '#field_decl'
+      - include: '#function_type'
       - include: '#var_decl'
       - include: '#label'
       - include: '#punctuation'

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -28,6 +28,28 @@ repository:
       - name: constant.character.escape.hexidecimal.zig
         match: \\u\{[a-fA-F0-9]{1,6}\}
 
+  param_list:
+    begin: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*'
+    beginCaptures:
+      '1':
+        name: storage.modifier.zig
+      '2':
+        name: variable.parameter.zig
+      '3':
+        name: punctuation.terminator.zig
+
+    contentName: storage.type.zig
+
+    end: '(?:(,)|(?:\)))'
+    endCaptures:
+      '1':
+        name: punctuation.separator.zig
+      '2':
+        name: punctuation.section.parens.end.zig
+
+    patterns:
+      - include: '#main'
+
   storage_modifier:
     name: storage.modifier.zig
     match: '\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\b'
@@ -163,7 +185,7 @@ repository:
   storage:
     patterns:
       - name: storage.type.zig
-        match: '\b(bool|void|noreturn|type|anyerror|promise)\b'
+        match: '\b(bool|void|noreturn|type|anyerror|anyframe)\b'
 
       - name: storage.type.integer.zig
         match: '\b(?<!\.)([iu][0-9]\d*|[iu]size|comptime_int)\b'
@@ -227,20 +249,11 @@ repository:
       #     '5':
       #       name: variable.other.zig
 
-      - begin: '(\()'
-        beginCaptures:
-          '1':
-            name: punctuation.section.parens.begin.zig
+      - match: '(\()'
+        name: punctuation.section.parens.begin.zig
 
-        contentName: meta.group.zig
-
-        end: '(\))'
-        endCaptures:
-          '1':
-            name: punctuation.section.parens.end.zig
-
-        patterns:
-          - include: '#main'
+      - match: '(\))'
+        name: punctuation.section.parens.end.zig
 
   label:
     match: '\b(break|continue)\s*:\s*([a-zA-Z_]\w*|@\".+\")\b|\b(?!\d)([a-zA-Z_]\w*|@\".+\")\b(?=\s*:\s*(?:\{|while\b))'
@@ -294,6 +307,7 @@ repository:
       #     '5':
       #       name: keyword.operator.assignment.zig
 
+      # - include: '#param_list'
       - include: '#function_def'
       - include: '#function'
       - include: '#label'

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -36,7 +36,7 @@ repository:
       '2':
         name: punctuation.separator.zig
 
-    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")?\s*(?:(,)|(\)))'
+    end: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?\s*(?:(\))|(,))'
     endCaptures:
       '1':
         name: storage.type.zig
@@ -46,6 +46,9 @@ repository:
         name: punctuation.section.parens.end.zig
 
     patterns:
+      - match: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")'
+        name: storage.type.zig
+
       - include: '#main'
 
   field_decl:
@@ -56,7 +59,7 @@ repository:
       '2':
         name: punctuation.separator.zig
 
-    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|\s*(=)\s*|(?=\n|\r))'
+    end: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(?:(,)|\s*(=)\s*|(?=\n|\r))'
     endCaptures:
       '1':
         name: storage.type.zig
@@ -203,7 +206,7 @@ repository:
   storage:
     patterns:
       - name: storage.type.zig
-        match: '\b(bool|void|noreturn|type|anyerror|anyframe)\b'
+        match: '\b(bool|void|noreturn|type|anyerror|anyframe|promise)\b'
 
       - name: storage.type.integer.zig
         match: '\b(?<!\.)([iu][0-9]\d*|[iu]size|comptime_int)\b'
@@ -280,7 +283,7 @@ repository:
       '2':
         name: punctuation.section.parens.begin.zig
 
-    end: '(?<=\))([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+    end: '(?<=\))([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")'
     endCaptures:
       '1':
         name: storage.type.zig
@@ -289,7 +292,7 @@ repository:
       - include: '#param_list'
       - include: '#main'
 
-      - match: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+      - match: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")'
         name: storage.type.zig
 
   function_call:
@@ -306,7 +309,7 @@ repository:
 
     contentName: meta.function.parameters.zig
 
-    end: '(?<=\))\s*([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+    end: '(?<=\))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")'
     endCaptures:
       '1':
         name: storage.type.zig
@@ -315,7 +318,7 @@ repository:
       - include: '#param_list'
       - include: '#main'
 
-      - match: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+      - match: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")'
         name: storage.type.zig
 
   var_decl:
@@ -336,8 +339,12 @@ repository:
     patterns:
       - include: '#main'
 
-      - match: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")'
+      - match: '([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")'
         name: storage.type.zig
+
+  enum_literal:
+    match: '(?<!\w)(\.(?:[a-zA-Z_][a-zA-Z0-9_]*|@\".+\"))'
+    name: constant.language.enum
 
   main:
     patterns:
@@ -359,3 +366,4 @@ repository:
       - include: '#block'
       - include: '#function_def'
       - include: '#function_call'
+      - include: '#enum_literal'

--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -276,24 +276,29 @@ repository:
     name: variable.function.zig
     match: '(?<!fn)\b([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()'
 
+  var_decl:
+    begin: '\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)'
+    beginCaptures:
+      '1':
+        name: storage.modifier.zig
+      '2':
+        name: variable.other.zig
+      '3':
+        name: punctuation.separator.zig
+
+    end: '([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(=)'
+    endCaptures:
+      '1':
+        name: storage.type.zig
+      '2':
+        name: keyword.operator.assignment.zig
+
+    patterns:
+      - include: '#main'
+
   main:
     patterns:
-      # variable/constant declaration
-      # - match: '\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(=)'
-      #   captures:
-      #     '1':
-      #       name: storage.modifier.zig
-      #     '2':
-      #       name: variable.other.zig
-      #     '3':
-      #       name: punctuation.terminator.zig
-      #     '4':
-      #       name: storage.type.zig
-      #     '5':
-      #       name: keyword.operator.assignment.zig
-
-      # - include: '#param_list'
-      
+      - include: '#var_decl'
       - include: '#label'
       - include: '#punctuation'
       - include: '#storage_modifier'
@@ -307,5 +312,5 @@ repository:
       - include: '#support'
       - include: '#field_decl'
       - include: '#block'
-      - include: '#function_def'
       - include: '#function_call'
+      - include: '#function_def'

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -243,6 +243,51 @@
 				</dict>
 			</array>
 		</dict>
+		<key>field_decl</key>
+		<dict>
+			<key>begin</key>
+			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)\s*</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.member.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.zig</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|\s*(=)\s*|(?=\n|\r))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.zig</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.zig</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#main</string>
+				</dict>
+			</array>
+		</dict>
 		<key>function_call</key>
 		<dict>
 			<key>match</key>
@@ -283,7 +328,48 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#param_field</string>
+					<string>#param_list</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#main</string>
+				</dict>
+			</array>
+		</dict>
+		<key>function_type</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(fn)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.function.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.begin.zig</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>meta.parameters.zig</string>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.end.zig</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#param_list</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -354,6 +440,14 @@
 		<dict>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#field_decl</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_type</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#var_decl</string>
@@ -468,7 +562,7 @@
 				</dict>
 			</array>
 		</dict>
-		<key>param_field</key>
+		<key>param_list</key>
 		<dict>
 			<key>begin</key>
 			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)\s*</string>
@@ -697,15 +791,10 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(=)</string>
+			<string>\s*(=)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.zig</string>
-				</dict>
-				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.operator.assignment.zig</string>
@@ -716,6 +805,12 @@
 				<dict>
 					<key>include</key>
 					<string>#main</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+					<key>name</key>
+					<string>storage.type.zig</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -196,213 +196,28 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(packed|extern)?\b\s*(union\b)(?:(\()([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(\)))?\s*({)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.union.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.union.zig</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.begin.zig</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.zig</string>
-						</dict>
-						<key>6</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.end.zig</string>
-						</dict>
-						<key>7</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.union</string>
-					<key>end</key>
-					<string>(})</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.end.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#main</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[({])</string>
+					<key>name</key>
+					<string>entity.name.union.zig</string>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(packed|extern)?\b\s*(struct)\s*({)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.struct.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.struct.zig</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.struct.zig</string>
-					<key>end</key>
-					<string>(})</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.end.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#main</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])</string>
+					<key>name</key>
+					<string>entity.name.struct.zig</string>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(extern)?\b\s*(enum\b)(?:(\()([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(\)))?\s*({)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.enum.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.enum.zig</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.begin.zig</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.zig</string>
-						</dict>
-						<key>6</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.end.zig</string>
-						</dict>
-						<key>7</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.enum.zig</string>
-					<key>end</key>
-					<string>(})</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.end.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#main</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])</string>
+					<key>name</key>
+					<string>entity.name.enum.zig</string>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>(?:([a-zA-Z_]\w*|@\".+\")\s*=\s*)?\b(error)\b\s*({)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.error.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.error.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.error.zig</string>
-					<key>end</key>
-					<string>(})</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.end.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#main</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[({])</string>
+					<key>name</key>
+					<string>entity.name.error.zig</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -428,96 +243,19 @@
 				</dict>
 			</array>
 		</dict>
-		<key>field_decl</key>
+		<key>function</key>
 		<dict>
-			<key>begin</key>
-			<string>([a-zA-Z_]\w*|@\".+\")\s*(:)\s*</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>variable.other.member.zig</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.terminator.zig</string>
-				</dict>
-			</dict>
-			<key>contentName</key>
-			<string>storage.type.zig</string>
-			<key>end</key>
-			<string>(?:(,)|(?:\n|\r))</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.zig</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#main</string>
-				</dict>
-			</array>
+			<key>match</key>
+			<string>(?&lt;!fn)\b([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()</string>
+			<key>name</key>
+			<string>variable.function.zig</string>
 		</dict>
-		<key>func_call</key>
+		<key>function_def</key>
 		<dict>
-			<key>begin</key>
-			<string>([a-zA-Z_]\w*|@\".+\")(\()</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>variable.function.zig</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.parens.begin.zig</string>
-				</dict>
-			</dict>
-			<key>contentName</key>
-			<string>meta.function-call.zig</string>
-			<key>end</key>
-			<string>(\))</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.parens.end.zig</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#main</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.end.zig</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?:(,)|(?:\)))</string>
-				</dict>
-			</array>
+			<key>match</key>
+			<string>(?&lt;=fn)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()</string>
+			<key>name</key>
+			<string>entity.name.function</string>
 		</dict>
 		<key>keywords</key>
 		<dict>
@@ -531,7 +269,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(async|await|suspend|resume|cancel)\b</string>
+					<string>\b(noasync|async|await|suspend|resume|cancel)\b</string>
 					<key>name</key>
 					<string>keyword.control.async.zig</string>
 				</dict>
@@ -549,203 +287,46 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\busingnamespace\b</string>
+					<string>\b(usingnamespace|use)\b</string>
 					<key>name</key>
 					<string>keyword.other.usingnamespace.zig</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\btest\b</string>
-					<key>name</key>
-					<string>keyword.other.test.zig</string>
 				</dict>
 			</array>
 		</dict>
 		<key>label</key>
 		<dict>
-			<key>patterns</key>
-			<array>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
 				<dict>
-					<key>match</key>
-					<string>(?&lt;!\w):([a-zA-Z_]\w*|@\".+\")</string>
+					<key>name</key>
+					<string>keyword.control.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
 					<key>name</key>
 					<string>entity.name.label.zig</string>
 				</dict>
+				<key>3</key>
 				<dict>
-					<key>begin</key>
-					<string>([a-zA-Z_]\w*|@\".+\"):\s*(?:({)|(while|for))</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.label.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.begin.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.zig</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(})</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.braces.end.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#main</string>
-						</dict>
-					</array>
+					<key>name</key>
+					<string>entity.name.label.zig</string>
 				</dict>
-			</array>
+			</dict>
+			<key>match</key>
+			<string>\b(break|continue)\s*:\s*([a-zA-Z_]\w*|@\".+\")\b|\b(?!\d)([a-zA-Z_]\w*|@\".+\")\b(?=\s*:\s*(?:\{|while\b))</string>
 		</dict>
 		<key>main</key>
 		<dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>\b(fn)(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.function.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.parameters.zig</string>
-					<key>end</key>
-					<string>(\))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.end.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>captures</key>
-							<dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>storage.type.zig</string>
-								</dict>
-								<key>2</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.separator.zig</string>
-								</dict>
-							</dict>
-							<key>match</key>
-							<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(,)?</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>\b(fn)\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.function.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.function.parameters.zig</string>
-					<key>end</key>
-					<string>(?&lt;=\))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#param_list</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.terminator.zig</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.zig</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.assignment.zig</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(=)</string>
+					<key>include</key>
+					<string>#function_def</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#func_call</string>
+					<string>#function</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -831,68 +412,21 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>((?:\+|-|(?&lt;=\w)\s*\*)\%?|/(?!/)|%)</string>
+					<string>((?:\+|-|(?&lt;=[a-zA-Z_]|@\")\s*\*)\%?|/(?!/)|%)</string>
 					<key>name</key>
 					<string>keyword.operator.arithmetic.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(&lt;&lt;|&gt;&gt;|&amp;(?=\W)|\|(?=[^\|])|\^|~)</string>
+					<string>(&lt;&lt;|&gt;&gt;|&amp;(?=[a-zA-Z_]|@\")|\|(?=[^\|])|\^|~)</string>
 					<key>name</key>
 					<string>keyword.operator.bitwise.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(\+\+|\*\*|-&gt;|\.\?|\.\*|&amp;(?=\w)|\?|\|\||\.\.|\.\.\.)</string>
+					<string>(\+\+|\*\*|-&gt;|\.\?|\.\*|&amp;(?=[a-zA-Z_]|@\")|\?|\|\||\.{2,3})</string>
 					<key>name</key>
 					<string>keyword.operator.other.zig</string>
-				</dict>
-			</array>
-		</dict>
-		<key>param_list</key>
-		<dict>
-			<key>begin</key>
-			<string>(comptime|noalias)?\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.modifier.zig</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>variable.parameter.zig</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.terminator.zig</string>
-				</dict>
-			</dict>
-			<key>contentName</key>
-			<string>storage.type.zig</string>
-			<key>end</key>
-			<string>(?:(,)|(?:\)))</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.zig</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.parens.end.zig</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#main</string>
 				</dict>
 			</array>
 		</dict>
@@ -972,6 +506,74 @@
 					<string>\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\b</string>
 					<key>name</key>
 					<string>storage.type.c_compat.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\bfn\b</string>
+					<key>name</key>
+					<string>storage.type.function.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\btest\b</string>
+					<key>name</key>
+					<string>storage.type.test.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\bstruct\b</string>
+					<key>name</key>
+					<string>storage.type.struct.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\benum\b</string>
+					<key>name</key>
+					<string>storage.type.enum.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\bunion\b</string>
+					<key>name</key>
+					<string>storage.type.union.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\berror\b</string>
+					<key>name</key>
+					<string>storage.type.error.zig</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.other.zig</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.zig</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.other.zig</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.other.zig</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.zig</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -34,8 +34,6 @@
 					<string>punctuation.section.braces.begin.zig</string>
 				</dict>
 			</dict>
-			<key>contentName</key>
-			<string>meta.block.zig</string>
 			<key>end</key>
 			<string>(\})</string>
 			<key>endCaptures</key>
@@ -312,16 +310,14 @@
 					<string>punctuation.section.parens.begin.zig</string>
 				</dict>
 			</dict>
-			<key>contentName</key>
-			<string>meta.function.parameters.zig</string>
 			<key>end</key>
-			<string>(\))</string>
+			<string>(?&lt;=\))([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.section.parens.begin.zig</string>
+					<string>storage.type.zig</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
@@ -333,6 +329,12 @@
 				<dict>
 					<key>include</key>
 					<string>#main</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+					<key>name</key>
+					<string>storage.type.zig</string>
 				</dict>
 			</array>
 		</dict>
@@ -354,15 +356,15 @@
 				</dict>
 			</dict>
 			<key>contentName</key>
-			<string>meta.parameters.zig</string>
+			<string>meta.function.parameters.zig</string>
 			<key>end</key>
-			<string>(\))</string>
+			<string>(?&lt;=\))\s*([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.section.parens.end.zig</string>
+					<string>storage.type.zig</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
@@ -374,6 +376,12 @@
 				<dict>
 					<key>include</key>
 					<string>#main</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+					<key>name</key>
+					<string>storage.type.zig</string>
 				</dict>
 			</array>
 		</dict>
@@ -506,11 +514,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#function_call</string>
+					<string>#function_def</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#function_def</string>
+					<string>#function_call</string>
 				</dict>
 			</array>
 		</dict>
@@ -580,7 +588,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|(?=\)))</string>
+			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")?\s*(?:(,)|(\)))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -592,6 +600,11 @@
 				<dict>
 					<key>name</key>
 					<string>punctuation.separator.zig</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.end.zig</string>
 				</dict>
 			</dict>
 			<key>patterns</key>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -197,25 +197,25 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[({])</string>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:union)\s*[(\{])</string>
 					<key>name</key>
 					<string>entity.name.union.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])</string>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])</string>
 					<key>name</key>
 					<string>entity.name.struct.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[({])</string>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])</string>
 					<key>name</key>
 					<string>entity.name.enum.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[({])</string>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:error)\s*[(\{])</string>
 					<key>name</key>
 					<string>entity.name.error.zig</string>
 				</dict>
@@ -243,7 +243,7 @@
 				</dict>
 			</array>
 		</dict>
-		<key>function</key>
+		<key>function_call</key>
 		<dict>
 			<key>match</key>
 			<string>(?&lt;!fn)\b([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()</string>
@@ -252,10 +252,44 @@
 		</dict>
 		<key>function_def</key>
 		<dict>
-			<key>match</key>
-			<string>(?&lt;=fn)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?=\s*\()</string>
-			<key>name</key>
-			<string>entity.name.function</string>
+			<key>begin</key>
+			<string>(?&lt;=fn)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.begin.zig</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>meta.function.parameters.zig</string>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.begin.zig</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#param_field</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#main</string>
+				</dict>
+			</array>
 		</dict>
 		<key>keywords</key>
 		<dict>
@@ -322,14 +356,6 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#function_def</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#function</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#label</string>
 				</dict>
 				<dict>
@@ -380,6 +406,14 @@
 					<key>include</key>
 					<string>#block</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_def</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_call</string>
+				</dict>
 			</array>
 		</dict>
 		<key>operators</key>
@@ -412,7 +446,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>((?:\+|-|(?&lt;=[a-zA-Z_]|@\")\s*\*)\%?|/(?!/)|%)</string>
+					<string>((?:\+|-|\*)\%?|/(?!/)|%)</string>
 					<key>name</key>
 					<string>keyword.operator.arithmetic.zig</string>
 				</dict>
@@ -430,43 +464,36 @@
 				</dict>
 			</array>
 		</dict>
-		<key>param_list</key>
+		<key>param_field</key>
 		<dict>
 			<key>begin</key>
-			<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*</string>
+			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)\s*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.modifier.zig</string>
+					<string>variable.parameter.zig</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>variable.parameter.zig</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.terminator.zig</string>
+					<string>punctuation.separator.zig</string>
 				</dict>
 			</dict>
-			<key>contentName</key>
-			<string>storage.type.zig</string>
 			<key>end</key>
-			<string>(?:(,)|(?:\)))</string>
+			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|(?=\)))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.separator.zig</string>
+					<string>storage.type.zig</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.section.parens.end.zig</string>
+					<string>punctuation.separator.zig</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
@@ -570,38 +597,6 @@
 					<string>\berror\b</string>
 					<key>name</key>
 					<string>storage.type.error.zig</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.other.zig</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.zig</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.other.zig</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.other.zig</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.zig</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?:(\*+)\s*(const|allowzero|volatile)\b|(\*+)|(\?+))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -430,6 +430,53 @@
 				</dict>
 			</array>
 		</dict>
+		<key>param_list</key>
+		<dict>
+			<key>begin</key>
+			<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")\s*(:)\s*</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.zig</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.terminator.zig</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>storage.type.zig</string>
+			<key>end</key>
+			<string>(?:(,)|(?:\)))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.end.zig</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#main</string>
+				</dict>
+			</array>
+		</dict>
 		<key>punctuation</key>
 		<dict>
 			<key>patterns</key>
@@ -447,35 +494,16 @@
 					<string>punctuation.terminator.zig</string>
 				</dict>
 				<dict>
-					<key>begin</key>
+					<key>match</key>
 					<string>(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.begin.zig</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>meta.group.zig</string>
-					<key>end</key>
+					<key>name</key>
+					<string>punctuation.section.parens.begin.zig</string>
+				</dict>
+				<dict>
+					<key>match</key>
 					<string>(\))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.parens.end.zig</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#main</string>
-						</dict>
-					</array>
+					<key>name</key>
+					<string>punctuation.section.parens.end.zig</string>
 				</dict>
 			</array>
 		</dict>
@@ -485,7 +513,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(bool|void|noreturn|type|anyerror|promise)\b</string>
+					<string>\b(bool|void|noreturn|type|anyerror|anyframe)\b</string>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -422,7 +422,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(usingnamespace|use)\b</string>
+					<string>\b(usingnamespace)\b</string>
 					<key>name</key>
 					<string>keyword.other.usingnamespace.zig</string>
 				</dict>
@@ -668,7 +668,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(bool|void|noreturn|type|anyerror|anyframe|promise)\b</string>
+					<string>\b(bool|void|noreturn|type|anyerror|anyframe)\b</string>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -356,6 +356,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#var_decl</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#label</string>
 				</dict>
 				<dict>
@@ -408,15 +412,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#function_def</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#function_call</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#var_decl</string>
+					<string>#function_def</string>
 				</dict>
 			</array>
 		</dict>
@@ -677,8 +677,8 @@
 		<key>var_decl</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;=:).*</string>
-			<key>captures</key>
+			<string>\b(const|var)\s+([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(:)</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -693,24 +693,19 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.terminator.zig</string>
+					<string>punctuation.separator.zig</string>
 				</dict>
-				<key>4</key>
+			</dict>
+			<key>end</key>
+			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")\s*(=)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.assignment.zig</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(=)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.operator.assignment.zig</string>
@@ -721,12 +716,6 @@
 				<dict>
 					<key>include</key>
 					<string>#main</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
-					<key>name</key>
-					<string>storage.type.zig</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -241,6 +241,13 @@
 				</dict>
 			</array>
 		</dict>
+		<key>enum_literal</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)(\.(?:[a-zA-Z_][a-zA-Z0-9_]*|@\".+\"))</string>
+			<key>name</key>
+			<string>constant.language.enum</string>
+		</dict>
 		<key>field_decl</key>
 		<dict>
 			<key>begin</key>
@@ -259,7 +266,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")(?:(,)|\s*(=)\s*|(?=\n|\r))</string>
+			<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")(?:(,)|\s*(=)\s*|(?=\n|\r))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -311,7 +318,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?&lt;=\))([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+			<string>(?&lt;=\))([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -332,7 +339,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+					<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>
@@ -358,7 +365,7 @@
 			<key>contentName</key>
 			<string>meta.function.parameters.zig</string>
 			<key>end</key>
-			<string>(?&lt;=\))\s*([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+			<string>(?&lt;=\))\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -379,7 +386,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+					<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>
@@ -520,6 +527,10 @@
 					<key>include</key>
 					<string>#function_call</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#enum_literal</string>
+				</dict>
 			</array>
 		</dict>
 		<key>operators</key>
@@ -588,7 +599,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")?\s*(?:(,)|(\)))</string>
+			<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")?\s*(?:(\))|(,))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -609,6 +620,12 @@
 			</dict>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>match</key>
+					<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
+					<key>name</key>
+					<string>storage.type.zig</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#main</string>
@@ -651,7 +668,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(bool|void|noreturn|type|anyerror|anyframe)\b</string>
+					<string>\b(bool|void|noreturn|type|anyerror|anyframe|promise)\b</string>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>
@@ -821,7 +838,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>([a-zA-Z_][a-zA-Z0-9_]*|@\".+\")</string>
+					<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
 					<key>name</key>
 					<string>storage.type.zig</string>
 				</dict>

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -203,13 +203,13 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])</string>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:struct)\s*[(\{])</string>
 					<key>name</key>
 					<string>entity.name.struct.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum|struct|union)\s*[(\{])</string>
+					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")(?=\s*=\s*(?:(?:extern|packed)\s+)?(?:enum)\s*[(\{])</string>
 					<key>name</key>
 					<string>entity.name.enum.zig</string>
 				</dict>
@@ -413,6 +413,10 @@
 				<dict>
 					<key>include</key>
 					<string>#function_call</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#var_decl</string>
 				</dict>
 			</array>
 		</dict>
@@ -669,6 +673,62 @@
 			<string>(?&lt;!\w)@[^\"\d][a-zA-Z_]\w*\b</string>
 			<key>name</key>
 			<string>support.function.zig</string>
+		</dict>
+		<key>var_decl</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;=:).*</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.zig</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.other.zig</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.terminator.zig</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.zig</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.zig</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(=)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.zig</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#main</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([a-zA-Z_][a-zA-Z0-9_.]*|@\".+\")</string>
+					<key>name</key>
+					<string>storage.type.zig</string>
+				</dict>
+			</array>
 		</dict>
 	</dict>
 	<key>scopeName</key>

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -1,250 +1,65 @@
 {
-    "patterns": [
-        {
-            "include": "#main"
-        }
-    ], 
+    "scopeName": "source.zig", 
+    "name": "Zig", 
     "fileTypes": [
         "zig"
     ], 
-    "name": "Zig", 
-    "scopeName": "source.zig", 
     "repository": {
-        "field_decl": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "1": {
-                    "name": "variable.other.member.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "endCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "3": {
-                    "name": "keyword.operator.assignment.zig"
-                }, 
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ]
-        }, 
-        "container_decl": {
-            "patterns": [
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])", 
-                    "name": "entity.name.union.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])", 
-                    "name": "entity.name.struct.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])", 
-                    "name": "entity.name.enum.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])", 
-                    "name": "entity.name.error.zig"
-                }, 
-                {
-                    "captures": {
-                        "2": {
-                            "name": "punctuation.accessor.zig"
-                        }, 
-                        "3": {
-                            "name": "entity.name.error.zig"
-                        }, 
-                        "1": {
-                            "name": "storage.type.error.zig"
-                        }
-                    }, 
-                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")"
-                }
-            ]
-        }, 
-        "label": {
-            "captures": {
-                "2": {
-                    "name": "entity.name.label.zig"
-                }, 
-                "3": {
-                    "name": "entity.name.label.zig"
-                }, 
-                "1": {
-                    "name": "keyword.control.zig"
-                }
-            }, 
-            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))"
-        }, 
         "support": {
-            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b", 
-            "name": "support.function.zig"
+            "name": "support.function.zig", 
+            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b"
         }, 
-        "strings": {
+        "storage": {
             "patterns": [
                 {
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "match": "\\\\[^\\'][^\\']*?", 
-                            "name": "invalid.illegal.character.zig"
-                        }
-                    ], 
-                    "begin": "\\'", 
-                    "end": "\\'", 
-                    "name": "string.quoted.single.zig"
+                    "name": "storage.type.zig", 
+                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe|promise)\\b"
                 }, 
                 {
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "match": "\\\\[^\\'][^\\']*?", 
-                            "name": "invalid.illegal.character.zig"
-                        }
-                    ], 
-                    "begin": "c?\\\"", 
-                    "end": "\\\"", 
-                    "name": "string.quoted.double.zig"
+                    "name": "storage.type.integer.zig", 
+                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b"
                 }, 
                 {
-                    "begin": "c?\\\\\\\\", 
-                    "end": "$\\n?", 
-                    "name": "string.quoted.other.zig"
-                }
-            ]
-        }, 
-        "param_list": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "1": {
-                    "name": "variable.parameter.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "endCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "3": {
-                    "name": "punctuation.section.parens.end.zig"
-                }, 
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")?\\s*(?:(,)|(\\)))", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ]
-        }, 
-        "operators": {
-            "patterns": [
-                {
-                    "match": "\\b!\\b", 
-                    "name": "keyword.operator.zig"
+                    "name": "storage.type.float.zig", 
+                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b"
                 }, 
                 {
-                    "match": "(==|(?:!|>|<)=?)", 
-                    "name": "keyword.operator.logical.zig"
+                    "name": "storage.type.c_compat.zig", 
+                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b"
                 }, 
                 {
-                    "match": "\\b(and|or)\\b", 
-                    "name": "keyword.operator.word.zig"
+                    "name": "storage.type.function.zig", 
+                    "match": "\\bfn\\b"
                 }, 
                 {
-                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)", 
-                    "name": "keyword.operator.assignment.zig"
+                    "name": "storage.type.test.zig", 
+                    "match": "\\btest\\b"
                 }, 
                 {
-                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)", 
-                    "name": "keyword.operator.arithmetic.zig"
+                    "name": "storage.type.struct.zig", 
+                    "match": "\\bstruct\\b"
                 }, 
                 {
-                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)", 
-                    "name": "keyword.operator.bitwise.zig"
+                    "name": "storage.type.enum.zig", 
+                    "match": "\\benum\\b"
                 }, 
                 {
-                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})", 
-                    "name": "keyword.operator.other.zig"
-                }
-            ]
-        }, 
-        "punctuation": {
-            "patterns": [
-                {
-                    "match": ",", 
-                    "name": "punctuation.separator.zig"
+                    "name": "storage.type.union.zig", 
+                    "match": "\\bunion\\b"
                 }, 
                 {
-                    "match": ";", 
-                    "name": "punctuation.terminator.zig"
-                }, 
-                {
-                    "match": "(\\()", 
-                    "name": "punctuation.section.parens.begin.zig"
-                }, 
-                {
-                    "match": "(\\))", 
-                    "name": "punctuation.section.parens.end.zig"
-                }
-            ]
-        }, 
-        "block": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.section.braces.begin.zig"
-                }, 
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.braces.end.zig"
-                }
-            }, 
-            "end": "(\\})", 
-            "patterns": [
-                {
-                    "include": "#main"
+                    "name": "storage.type.error.zig", 
+                    "match": "\\berror\\b"
                 }
             ]
         }, 
         "function_def": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.section.parens.begin.zig"
-                }, 
-                "1": {
-                    "name": "entity.name.function"
-                }
-            }, 
-            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
+            "end": "(?<=\\))([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")", 
             "endCaptures": {
                 "1": {
                     "name": "storage.type.zig"
                 }
             }, 
-            "end": "(?<=\\))([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
             "patterns": [
                 {
                     "include": "#param_list"
@@ -253,177 +68,134 @@
                     "include": "#main"
                 }, 
                 {
-                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }
+            ], 
+            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.function"
+                }, 
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }
+            }
+        }, 
+        "field_decl": {
+            "end": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
+            "endCaptures": {
+                "1": {
                     "name": "storage.type.zig"
+                }, 
+                "3": {
+                    "name": "keyword.operator.assignment.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
                 }
-            ]
-        }, 
-        "comments": {
+            }, 
             "patterns": [
                 {
-                    "match": "TODO", 
-                    "name": "comment.line.todo.zig"
-                }, 
-                {
-                    "patterns": [
-                        {
-                            "include": "#todo"
-                        }
-                    ], 
-                    "begin": "//[^/]", 
-                    "end": "$\\n?", 
-                    "name": "comment.line.zig"
-                }, 
-                {
-                    "begin": "///", 
-                    "end": "$\\n?", 
-                    "name": "comment.line.documentation.zig"
+                    "include": "#main"
                 }
-            ]
+            ], 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "beginCaptures": {
+                "1": {
+                    "name": "variable.other.member.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }
+            }
         }, 
-        "character_escapes": {
-            "patterns": [
-                {
-                    "match": "\\\\n", 
-                    "name": "constant.character.escape.newline.zig"
-                }, 
-                {
-                    "match": "\\\\r", 
-                    "name": "constant.character.escape.carrigereturn.zig"
-                }, 
-                {
-                    "match": "\\\\t", 
-                    "name": "constant.character.escape.tabulator.zig"
-                }, 
-                {
-                    "match": "\\\\\\\\", 
-                    "name": "constant.character.escape.backslash.zig"
-                }, 
-                {
-                    "match": "\\\\'", 
-                    "name": "constant.character.escape.single-quote.zig"
-                }, 
-                {
-                    "match": "\\\\\\\"", 
-                    "name": "constant.character.escape.double-quote.zig"
-                }, 
-                {
-                    "match": "\\\\x[a-fA-F0-9]{2}", 
-                    "name": "constant.character.escape.hexidecimal.zig"
-                }, 
-                {
-                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}", 
-                    "name": "constant.character.escape.hexidecimal.zig"
-                }
-            ]
+        "enum_literal": {
+            "name": "constant.language.enum", 
+            "match": "(?<!\\w)(\\.(?:[a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\"))"
         }, 
         "keywords": {
             "patterns": [
                 {
-                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b", 
-                    "name": "keyword.control.zig"
+                    "name": "keyword.control.zig", 
+                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b"
                 }, 
                 {
-                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b", 
-                    "name": "keyword.control.async.zig"
+                    "name": "keyword.control.async.zig", 
+                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b"
                 }, 
                 {
-                    "match": "\\b(if|else|switch|try|catch|orelse)\\b", 
-                    "name": "keyword.control.conditional.zig"
+                    "name": "keyword.control.conditional.zig", 
+                    "match": "\\b(if|else|switch|try|catch|orelse)\\b"
                 }, 
                 {
-                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b", 
-                    "name": "keyword.control.import.zig"
+                    "name": "keyword.control.import.zig", 
+                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b"
                 }, 
                 {
-                    "match": "\\b(usingnamespace|use)\\b", 
-                    "name": "keyword.other.usingnamespace.zig"
+                    "name": "keyword.other.usingnamespace.zig", 
+                    "match": "\\b(usingnamespace|use)\\b"
                 }
             ]
         }, 
-        "storage": {
+        "var_decl": {
+            "end": "\\s*(=)", 
+            "endCaptures": {
+                "1": {
+                    "name": "keyword.operator.assignment.zig"
+                }
+            }, 
             "patterns": [
                 {
-                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe)\\b", 
+                    "include": "#main"
+                }, 
+                {
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }
+            ], 
+            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.modifier.zig"
+                }, 
+                "3": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "2": {
+                    "name": "variable.other.zig"
+                }
+            }
+        }, 
+        "function_type": {
+            "endCaptures": {
+                "1": {
                     "name": "storage.type.zig"
+                }
+            }, 
+            "contentName": "meta.function.parameters.zig", 
+            "begin": "\\b(fn)\\s*(\\()", 
+            "end": "(?<=\\))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")", 
+            "patterns": [
+                {
+                    "include": "#param_list"
                 }, 
                 {
-                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b", 
-                    "name": "storage.type.integer.zig"
+                    "include": "#main"
                 }, 
                 {
-                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b", 
-                    "name": "storage.type.float.zig"
-                }, 
-                {
-                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b", 
-                    "name": "storage.type.c_compat.zig"
-                }, 
-                {
-                    "match": "\\bfn\\b", 
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }
+            ], 
+            "beginCaptures": {
+                "1": {
                     "name": "storage.type.function.zig"
                 }, 
-                {
-                    "match": "\\btest\\b", 
-                    "name": "storage.type.test.zig"
-                }, 
-                {
-                    "match": "\\bstruct\\b", 
-                    "name": "storage.type.struct.zig"
-                }, 
-                {
-                    "match": "\\benum\\b", 
-                    "name": "storage.type.enum.zig"
-                }, 
-                {
-                    "match": "\\bunion\\b", 
-                    "name": "storage.type.union.zig"
-                }, 
-                {
-                    "match": "\\berror\\b", 
-                    "name": "storage.type.error.zig"
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
                 }
-            ]
-        }, 
-        "constants": {
-            "patterns": [
-                {
-                    "match": "\\b(null|undefined|true|false)\\b", 
-                    "name": "constant.language.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.hexadecimal.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.octal.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.binary.zig"
-                }, 
-                {
-                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b", 
-                    "name": "constant.numeric.float.zig"
-                }, 
-                {
-                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b", 
-                    "name": "constant.numeric.float.hexadecimal.zig"
-                }
-            ]
-        }, 
-        "storage_modifier": {
-            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b", 
-            "name": "storage.modifier.zig"
-        }, 
-        "function_call": {
-            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
-            "name": "variable.function.zig"
+            }
         }, 
         "main": {
             "patterns": [
@@ -480,67 +252,306 @@
                 }, 
                 {
                     "include": "#function_call"
+                }, 
+                {
+                    "include": "#enum_literal"
                 }
             ]
         }, 
-        "function_type": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.section.parens.begin.zig"
+        "storage_modifier": {
+            "name": "storage.modifier.zig", 
+            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b"
+        }, 
+        "constants": {
+            "patterns": [
+                {
+                    "name": "constant.language.zig", 
+                    "match": "\\b(null|undefined|true|false)\\b"
                 }, 
+                {
+                    "name": "constant.numeric.integer.zig", 
+                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b"
+                }, 
+                {
+                    "name": "constant.numeric.integer.hexadecimal.zig", 
+                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b"
+                }, 
+                {
+                    "name": "constant.numeric.integer.octal.zig", 
+                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b"
+                }, 
+                {
+                    "name": "constant.numeric.integer.binary.zig", 
+                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b"
+                }, 
+                {
+                    "name": "constant.numeric.float.zig", 
+                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b"
+                }, 
+                {
+                    "name": "constant.numeric.float.hexadecimal.zig", 
+                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b"
+                }
+            ]
+        }, 
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.line.todo.zig", 
+                    "match": "TODO"
+                }, 
+                {
+                    "end": "$\\n?", 
+                    "name": "comment.line.zig", 
+                    "patterns": [
+                        {
+                            "include": "#todo"
+                        }
+                    ], 
+                    "begin": "//[^/]"
+                }, 
+                {
+                    "end": "$\\n?", 
+                    "name": "comment.line.documentation.zig", 
+                    "begin": "///"
+                }
+            ]
+        }, 
+        "container_decl": {
+            "patterns": [
+                {
+                    "name": "entity.name.union.zig", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])"
+                }, 
+                {
+                    "name": "entity.name.struct.zig", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])"
+                }, 
+                {
+                    "name": "entity.name.enum.zig", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])"
+                }, 
+                {
+                    "name": "entity.name.error.zig", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])"
+                }, 
+                {
+                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")", 
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.error.zig"
+                        }, 
+                        "3": {
+                            "name": "entity.name.error.zig"
+                        }, 
+                        "2": {
+                            "name": "punctuation.accessor.zig"
+                        }
+                    }
+                }
+            ]
+        }, 
+        "operators": {
+            "patterns": [
+                {
+                    "name": "keyword.operator.zig", 
+                    "match": "\\b!\\b"
+                }, 
+                {
+                    "name": "keyword.operator.logical.zig", 
+                    "match": "(==|(?:!|>|<)=?)"
+                }, 
+                {
+                    "name": "keyword.operator.word.zig", 
+                    "match": "\\b(and|or)\\b"
+                }, 
+                {
+                    "name": "keyword.operator.assignment.zig", 
+                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)"
+                }, 
+                {
+                    "name": "keyword.operator.arithmetic.zig", 
+                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)"
+                }, 
+                {
+                    "name": "keyword.operator.bitwise.zig", 
+                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)"
+                }, 
+                {
+                    "name": "keyword.operator.other.zig", 
+                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})"
+                }
+            ]
+        }, 
+        "block": {
+            "end": "(\\})", 
+            "endCaptures": {
                 "1": {
-                    "name": "storage.type.function.zig"
+                    "name": "punctuation.section.braces.end.zig"
                 }
             }, 
             "patterns": [
                 {
-                    "include": "#param_list"
-                }, 
-                {
                     "include": "#main"
-                }, 
-                {
-                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
-                    "name": "storage.type.zig"
                 }
             ], 
-            "begin": "\\b(fn)\\s*(\\()", 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.section.braces.begin.zig"
+                }
+            }
+        }, 
+        "param_list": {
+            "end": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(?:(\\))|(,))", 
             "endCaptures": {
                 "1": {
                     "name": "storage.type.zig"
-                }
-            }, 
-            "end": "(?<=\\))\\s*([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
-            "contentName": "meta.function.parameters.zig"
-        }, 
-        "var_decl": {
-            "beginCaptures": {
-                "2": {
-                    "name": "variable.other.zig"
                 }, 
                 "3": {
-                    "name": "punctuation.separator.zig"
+                    "name": "punctuation.section.parens.end.zig"
                 }, 
-                "1": {
-                    "name": "storage.modifier.zig"
+                "2": {
+                    "name": "punctuation.separator.zig"
                 }
             }, 
-            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
-            "endCaptures": {
-                "1": {
-                    "name": "keyword.operator.assignment.zig"
-                }
-            }, 
-            "end": "\\s*(=)", 
             "patterns": [
                 {
-                    "include": "#main"
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
                 }, 
                 {
-                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
-                    "name": "storage.type.zig"
+                    "include": "#main"
+                }
+            ], 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "beginCaptures": {
+                "1": {
+                    "name": "variable.parameter.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }
+            }
+        }, 
+        "strings": {
+            "patterns": [
+                {
+                    "end": "\\'", 
+                    "name": "string.quoted.single.zig", 
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "name": "invalid.illegal.character.zig", 
+                            "match": "\\\\[^\\'][^\\']*?"
+                        }
+                    ], 
+                    "begin": "\\'"
+                }, 
+                {
+                    "end": "\\\"", 
+                    "name": "string.quoted.double.zig", 
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "name": "invalid.illegal.character.zig", 
+                            "match": "\\\\[^\\'][^\\']*?"
+                        }
+                    ], 
+                    "begin": "c?\\\""
+                }, 
+                {
+                    "end": "$\\n?", 
+                    "name": "string.quoted.other.zig", 
+                    "begin": "c?\\\\\\\\"
+                }
+            ]
+        }, 
+        "label": {
+            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
+            "captures": {
+                "1": {
+                    "name": "keyword.control.zig"
+                }, 
+                "3": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "2": {
+                    "name": "entity.name.label.zig"
+                }
+            }
+        }, 
+        "function_call": {
+            "name": "variable.function.zig", 
+            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()"
+        }, 
+        "character_escapes": {
+            "patterns": [
+                {
+                    "name": "constant.character.escape.newline.zig", 
+                    "match": "\\\\n"
+                }, 
+                {
+                    "name": "constant.character.escape.carrigereturn.zig", 
+                    "match": "\\\\r"
+                }, 
+                {
+                    "name": "constant.character.escape.tabulator.zig", 
+                    "match": "\\\\t"
+                }, 
+                {
+                    "name": "constant.character.escape.backslash.zig", 
+                    "match": "\\\\\\\\"
+                }, 
+                {
+                    "name": "constant.character.escape.single-quote.zig", 
+                    "match": "\\\\'"
+                }, 
+                {
+                    "name": "constant.character.escape.double-quote.zig", 
+                    "match": "\\\\\\\""
+                }, 
+                {
+                    "name": "constant.character.escape.hexidecimal.zig", 
+                    "match": "\\\\x[a-fA-F0-9]{2}"
+                }, 
+                {
+                    "name": "constant.character.escape.hexidecimal.zig", 
+                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}"
+                }
+            ]
+        }, 
+        "punctuation": {
+            "patterns": [
+                {
+                    "name": "punctuation.separator.zig", 
+                    "match": ","
+                }, 
+                {
+                    "name": "punctuation.terminator.zig", 
+                    "match": ";"
+                }, 
+                {
+                    "name": "punctuation.section.parens.begin.zig", 
+                    "match": "(\\()"
+                }, 
+                {
+                    "name": "punctuation.section.parens.end.zig", 
+                    "match": "(\\))"
                 }
             ]
         }
-    }
+    }, 
+    "patterns": [
+        {
+            "include": "#main"
+        }
+    ]
 }

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -1,5 +1,263 @@
 {
+    "patterns": [
+        {
+            "include": "#main"
+        }
+    ], 
+    "fileTypes": [
+        "zig"
+    ], 
+    "name": "Zig", 
+    "scopeName": "source.zig", 
     "repository": {
+        "field_decl": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "variable.other.member.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "endCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "3": {
+                    "name": "keyword.operator.assignment.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
+            "patterns": [
+                {
+                    "include": "#main"
+                }
+            ]
+        }, 
+        "container_decl": {
+            "patterns": [
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])", 
+                    "name": "entity.name.union.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])", 
+                    "name": "entity.name.struct.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])", 
+                    "name": "entity.name.enum.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])", 
+                    "name": "entity.name.error.zig"
+                }, 
+                {
+                    "captures": {
+                        "2": {
+                            "name": "punctuation.accessor.zig"
+                        }, 
+                        "3": {
+                            "name": "entity.name.error.zig"
+                        }, 
+                        "1": {
+                            "name": "storage.type.error.zig"
+                        }
+                    }, 
+                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")"
+                }
+            ]
+        }, 
+        "label": {
+            "captures": {
+                "2": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "3": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "1": {
+                    "name": "keyword.control.zig"
+                }
+            }, 
+            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))"
+        }, 
+        "support": {
+            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b", 
+            "name": "support.function.zig"
+        }, 
+        "strings": {
+            "patterns": [
+                {
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "match": "\\\\[^\\'][^\\']*?", 
+                            "name": "invalid.illegal.character.zig"
+                        }
+                    ], 
+                    "begin": "\\'", 
+                    "end": "\\'", 
+                    "name": "string.quoted.single.zig"
+                }, 
+                {
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "match": "\\\\[^\\'][^\\']*?", 
+                            "name": "invalid.illegal.character.zig"
+                        }
+                    ], 
+                    "begin": "c?\\\"", 
+                    "end": "\\\"", 
+                    "name": "string.quoted.double.zig"
+                }, 
+                {
+                    "begin": "c?\\\\\\\\", 
+                    "end": "$\\n?", 
+                    "name": "string.quoted.other.zig"
+                }
+            ]
+        }, 
+        "param_list": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "variable.parameter.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "endCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "3": {
+                    "name": "punctuation.section.parens.end.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")?\\s*(?:(,)|(\\)))", 
+            "patterns": [
+                {
+                    "include": "#main"
+                }
+            ]
+        }, 
+        "operators": {
+            "patterns": [
+                {
+                    "match": "\\b!\\b", 
+                    "name": "keyword.operator.zig"
+                }, 
+                {
+                    "match": "(==|(?:!|>|<)=?)", 
+                    "name": "keyword.operator.logical.zig"
+                }, 
+                {
+                    "match": "\\b(and|or)\\b", 
+                    "name": "keyword.operator.word.zig"
+                }, 
+                {
+                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)", 
+                    "name": "keyword.operator.assignment.zig"
+                }, 
+                {
+                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)", 
+                    "name": "keyword.operator.arithmetic.zig"
+                }, 
+                {
+                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)", 
+                    "name": "keyword.operator.bitwise.zig"
+                }, 
+                {
+                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})", 
+                    "name": "keyword.operator.other.zig"
+                }
+            ]
+        }, 
+        "punctuation": {
+            "patterns": [
+                {
+                    "match": ",", 
+                    "name": "punctuation.separator.zig"
+                }, 
+                {
+                    "match": ";", 
+                    "name": "punctuation.terminator.zig"
+                }, 
+                {
+                    "match": "(\\()", 
+                    "name": "punctuation.section.parens.begin.zig"
+                }, 
+                {
+                    "match": "(\\))", 
+                    "name": "punctuation.section.parens.end.zig"
+                }
+            ]
+        }, 
+        "block": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.section.braces.begin.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.braces.end.zig"
+                }
+            }, 
+            "end": "(\\})", 
+            "patterns": [
+                {
+                    "include": "#main"
+                }
+            ]
+        }, 
+        "function_def": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }, 
+                "1": {
+                    "name": "entity.name.function"
+                }
+            }, 
+            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "end": "(?<=\\))([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+            "patterns": [
+                {
+                    "include": "#param_list"
+                }, 
+                {
+                    "include": "#main"
+                }, 
+                {
+                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+                    "name": "storage.type.zig"
+                }
+            ]
+        }, 
         "comments": {
             "patterns": [
                 {
@@ -7,21 +265,165 @@
                     "name": "comment.line.todo.zig"
                 }, 
                 {
-                    "name": "comment.line.zig", 
-                    "end": "$\\n?", 
-                    "begin": "//[^/]", 
                     "patterns": [
                         {
                             "include": "#todo"
                         }
-                    ]
+                    ], 
+                    "begin": "//[^/]", 
+                    "end": "$\\n?", 
+                    "name": "comment.line.zig"
                 }, 
                 {
-                    "name": "comment.line.documentation.zig", 
+                    "begin": "///", 
                     "end": "$\\n?", 
-                    "begin": "///"
+                    "name": "comment.line.documentation.zig"
                 }
             ]
+        }, 
+        "character_escapes": {
+            "patterns": [
+                {
+                    "match": "\\\\n", 
+                    "name": "constant.character.escape.newline.zig"
+                }, 
+                {
+                    "match": "\\\\r", 
+                    "name": "constant.character.escape.carrigereturn.zig"
+                }, 
+                {
+                    "match": "\\\\t", 
+                    "name": "constant.character.escape.tabulator.zig"
+                }, 
+                {
+                    "match": "\\\\\\\\", 
+                    "name": "constant.character.escape.backslash.zig"
+                }, 
+                {
+                    "match": "\\\\'", 
+                    "name": "constant.character.escape.single-quote.zig"
+                }, 
+                {
+                    "match": "\\\\\\\"", 
+                    "name": "constant.character.escape.double-quote.zig"
+                }, 
+                {
+                    "match": "\\\\x[a-fA-F0-9]{2}", 
+                    "name": "constant.character.escape.hexidecimal.zig"
+                }, 
+                {
+                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}", 
+                    "name": "constant.character.escape.hexidecimal.zig"
+                }
+            ]
+        }, 
+        "keywords": {
+            "patterns": [
+                {
+                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b", 
+                    "name": "keyword.control.zig"
+                }, 
+                {
+                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b", 
+                    "name": "keyword.control.async.zig"
+                }, 
+                {
+                    "match": "\\b(if|else|switch|try|catch|orelse)\\b", 
+                    "name": "keyword.control.conditional.zig"
+                }, 
+                {
+                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b", 
+                    "name": "keyword.control.import.zig"
+                }, 
+                {
+                    "match": "\\b(usingnamespace|use)\\b", 
+                    "name": "keyword.other.usingnamespace.zig"
+                }
+            ]
+        }, 
+        "storage": {
+            "patterns": [
+                {
+                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe)\\b", 
+                    "name": "storage.type.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b", 
+                    "name": "storage.type.integer.zig"
+                }, 
+                {
+                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b", 
+                    "name": "storage.type.float.zig"
+                }, 
+                {
+                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b", 
+                    "name": "storage.type.c_compat.zig"
+                }, 
+                {
+                    "match": "\\bfn\\b", 
+                    "name": "storage.type.function.zig"
+                }, 
+                {
+                    "match": "\\btest\\b", 
+                    "name": "storage.type.test.zig"
+                }, 
+                {
+                    "match": "\\bstruct\\b", 
+                    "name": "storage.type.struct.zig"
+                }, 
+                {
+                    "match": "\\benum\\b", 
+                    "name": "storage.type.enum.zig"
+                }, 
+                {
+                    "match": "\\bunion\\b", 
+                    "name": "storage.type.union.zig"
+                }, 
+                {
+                    "match": "\\berror\\b", 
+                    "name": "storage.type.error.zig"
+                }
+            ]
+        }, 
+        "constants": {
+            "patterns": [
+                {
+                    "match": "\\b(null|undefined|true|false)\\b", 
+                    "name": "constant.language.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.hexadecimal.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.octal.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.binary.zig"
+                }, 
+                {
+                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b", 
+                    "name": "constant.numeric.float.zig"
+                }, 
+                {
+                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b", 
+                    "name": "constant.numeric.float.hexadecimal.zig"
+                }
+            ]
+        }, 
+        "storage_modifier": {
+            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b", 
+            "name": "storage.modifier.zig"
+        }, 
+        "function_call": {
+            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
+            "name": "variable.function.zig"
         }, 
         "main": {
             "patterns": [
@@ -74,394 +476,10 @@
                     "include": "#block"
                 }, 
                 {
-                    "include": "#function_call"
-                }, 
-                {
                     "include": "#function_def"
-                }
-            ]
-        }, 
-        "support": {
-            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b", 
-            "name": "support.function.zig"
-        }, 
-        "block": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.section.braces.begin.zig"
-                }, 
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ], 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.braces.end.zig"
-                }
-            }, 
-            "end": "(\\})", 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
-            "contentName": "meta.block.zig"
-        }, 
-        "field_decl": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "1": {
-                    "name": "variable.other.member.zig"
-                }
-            }, 
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
-            "endCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "3": {
-                    "name": "keyword.operator.assignment.zig"
-                }, 
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ]
-        }, 
-        "keywords": {
-            "patterns": [
-                {
-                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b", 
-                    "name": "keyword.control.zig"
                 }, 
                 {
-                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b", 
-                    "name": "keyword.control.async.zig"
-                }, 
-                {
-                    "match": "\\b(if|else|switch|try|catch|orelse)\\b", 
-                    "name": "keyword.control.conditional.zig"
-                }, 
-                {
-                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b", 
-                    "name": "keyword.control.import.zig"
-                }, 
-                {
-                    "match": "\\b(usingnamespace|use)\\b", 
-                    "name": "keyword.other.usingnamespace.zig"
-                }
-            ]
-        }, 
-        "character_escapes": {
-            "patterns": [
-                {
-                    "match": "\\\\n", 
-                    "name": "constant.character.escape.newline.zig"
-                }, 
-                {
-                    "match": "\\\\r", 
-                    "name": "constant.character.escape.carrigereturn.zig"
-                }, 
-                {
-                    "match": "\\\\t", 
-                    "name": "constant.character.escape.tabulator.zig"
-                }, 
-                {
-                    "match": "\\\\\\\\", 
-                    "name": "constant.character.escape.backslash.zig"
-                }, 
-                {
-                    "match": "\\\\'", 
-                    "name": "constant.character.escape.single-quote.zig"
-                }, 
-                {
-                    "match": "\\\\\\\"", 
-                    "name": "constant.character.escape.double-quote.zig"
-                }, 
-                {
-                    "match": "\\\\x[a-fA-F0-9]{2}", 
-                    "name": "constant.character.escape.hexidecimal.zig"
-                }, 
-                {
-                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}", 
-                    "name": "constant.character.escape.hexidecimal.zig"
-                }
-            ]
-        }, 
-        "function_def": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.section.parens.begin.zig"
-                }, 
-                "1": {
-                    "name": "entity.name.function"
-                }
-            }, 
-            "patterns": [
-                {
-                    "include": "#param_list"
-                }, 
-                {
-                    "include": "#main"
-                }
-            ], 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.parens.begin.zig"
-                }
-            }, 
-            "end": "(\\))", 
-            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
-            "contentName": "meta.function.parameters.zig"
-        }, 
-        "constants": {
-            "patterns": [
-                {
-                    "match": "\\b(null|undefined|true|false)\\b", 
-                    "name": "constant.language.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.hexadecimal.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.octal.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.binary.zig"
-                }, 
-                {
-                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b", 
-                    "name": "constant.numeric.float.zig"
-                }, 
-                {
-                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b", 
-                    "name": "constant.numeric.float.hexadecimal.zig"
-                }
-            ]
-        }, 
-        "storage_modifier": {
-            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b", 
-            "name": "storage.modifier.zig"
-        }, 
-        "storage": {
-            "patterns": [
-                {
-                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe)\\b", 
-                    "name": "storage.type.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b", 
-                    "name": "storage.type.integer.zig"
-                }, 
-                {
-                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b", 
-                    "name": "storage.type.float.zig"
-                }, 
-                {
-                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b", 
-                    "name": "storage.type.c_compat.zig"
-                }, 
-                {
-                    "match": "\\bfn\\b", 
-                    "name": "storage.type.function.zig"
-                }, 
-                {
-                    "match": "\\btest\\b", 
-                    "name": "storage.type.test.zig"
-                }, 
-                {
-                    "match": "\\bstruct\\b", 
-                    "name": "storage.type.struct.zig"
-                }, 
-                {
-                    "match": "\\benum\\b", 
-                    "name": "storage.type.enum.zig"
-                }, 
-                {
-                    "match": "\\bunion\\b", 
-                    "name": "storage.type.union.zig"
-                }, 
-                {
-                    "match": "\\berror\\b", 
-                    "name": "storage.type.error.zig"
-                }
-            ]
-        }, 
-        "label": {
-            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
-            "captures": {
-                "2": {
-                    "name": "entity.name.label.zig"
-                }, 
-                "3": {
-                    "name": "entity.name.label.zig"
-                }, 
-                "1": {
-                    "name": "keyword.control.zig"
-                }
-            }
-        }, 
-        "function_call": {
-            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
-            "name": "variable.function.zig"
-        }, 
-        "strings": {
-            "patterns": [
-                {
-                    "name": "string.quoted.single.zig", 
-                    "end": "\\'", 
-                    "begin": "\\'", 
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "match": "\\\\[^\\'][^\\']*?", 
-                            "name": "invalid.illegal.character.zig"
-                        }
-                    ]
-                }, 
-                {
-                    "name": "string.quoted.double.zig", 
-                    "end": "\\\"", 
-                    "begin": "c?\\\"", 
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "match": "\\\\[^\\'][^\\']*?", 
-                            "name": "invalid.illegal.character.zig"
-                        }
-                    ]
-                }, 
-                {
-                    "name": "string.quoted.other.zig", 
-                    "end": "$\\n?", 
-                    "begin": "c?\\\\\\\\"
-                }
-            ]
-        }, 
-        "punctuation": {
-            "patterns": [
-                {
-                    "match": ",", 
-                    "name": "punctuation.separator.zig"
-                }, 
-                {
-                    "match": ";", 
-                    "name": "punctuation.terminator.zig"
-                }, 
-                {
-                    "match": "(\\()", 
-                    "name": "punctuation.section.parens.begin.zig"
-                }, 
-                {
-                    "match": "(\\))", 
-                    "name": "punctuation.section.parens.end.zig"
-                }
-            ]
-        }, 
-        "param_list": {
-            "beginCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "1": {
-                    "name": "variable.parameter.zig"
-                }
-            }, 
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|(?=\\)))", 
-            "endCaptures": {
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ]
-        }, 
-        "container_decl": {
-            "patterns": [
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])", 
-                    "name": "entity.name.union.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])", 
-                    "name": "entity.name.struct.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])", 
-                    "name": "entity.name.enum.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])", 
-                    "name": "entity.name.error.zig"
-                }, 
-                {
-                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")", 
-                    "captures": {
-                        "2": {
-                            "name": "punctuation.accessor.zig"
-                        }, 
-                        "3": {
-                            "name": "entity.name.error.zig"
-                        }, 
-                        "1": {
-                            "name": "storage.type.error.zig"
-                        }
-                    }
-                }
-            ]
-        }, 
-        "var_decl": {
-            "beginCaptures": {
-                "2": {
-                    "name": "variable.other.zig"
-                }, 
-                "3": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "1": {
-                    "name": "storage.modifier.zig"
-                }
-            }, 
-            "end": "\\s*(=)", 
-            "endCaptures": {
-                "1": {
-                    "name": "keyword.operator.assignment.zig"
-                }
-            }, 
-            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }, 
-                {
-                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
-                    "name": "storage.type.zig"
+                    "include": "#function_call"
                 }
             ]
         }, 
@@ -480,58 +498,49 @@
                 }, 
                 {
                     "include": "#main"
+                }, 
+                {
+                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+                    "name": "storage.type.zig"
                 }
             ], 
+            "begin": "\\b(fn)\\s*(\\()", 
             "endCaptures": {
                 "1": {
-                    "name": "punctuation.section.parens.end.zig"
+                    "name": "storage.type.zig"
                 }
             }, 
-            "end": "(\\))", 
-            "begin": "\\b(fn)\\s*(\\()", 
-            "contentName": "meta.parameters.zig"
+            "end": "(?<=\\))\\s*([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+            "contentName": "meta.function.parameters.zig"
         }, 
-        "operators": {
+        "var_decl": {
+            "beginCaptures": {
+                "2": {
+                    "name": "variable.other.zig"
+                }, 
+                "3": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "storage.modifier.zig"
+                }
+            }, 
+            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
+            "endCaptures": {
+                "1": {
+                    "name": "keyword.operator.assignment.zig"
+                }
+            }, 
+            "end": "\\s*(=)", 
             "patterns": [
                 {
-                    "match": "\\b!\\b", 
-                    "name": "keyword.operator.zig"
+                    "include": "#main"
                 }, 
                 {
-                    "match": "(==|(?:!|>|<)=?)", 
-                    "name": "keyword.operator.logical.zig"
-                }, 
-                {
-                    "match": "\\b(and|or)\\b", 
-                    "name": "keyword.operator.word.zig"
-                }, 
-                {
-                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)", 
-                    "name": "keyword.operator.assignment.zig"
-                }, 
-                {
-                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)", 
-                    "name": "keyword.operator.arithmetic.zig"
-                }, 
-                {
-                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)", 
-                    "name": "keyword.operator.bitwise.zig"
-                }, 
-                {
-                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})", 
-                    "name": "keyword.operator.other.zig"
+                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+                    "name": "storage.type.zig"
                 }
             ]
         }
-    }, 
-    "name": "Zig", 
-    "scopeName": "source.zig", 
-    "fileTypes": [
-        "zig"
-    ], 
-    "patterns": [
-        {
-            "include": "#main"
-        }
-    ]
+    }
 }

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -26,6 +26,12 @@
         "main": {
             "patterns": [
                 {
+                    "include": "#field_decl"
+                }, 
+                {
+                    "include": "#function_type"
+                }, 
+                {
                     "include": "#var_decl"
                 }, 
                 {
@@ -102,19 +108,22 @@
             "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
             "contentName": "meta.block.zig"
         }, 
-        "param_field": {
+        "field_decl": {
             "beginCaptures": {
                 "2": {
                     "name": "punctuation.separator.zig"
                 }, 
                 "1": {
-                    "name": "variable.parameter.zig"
+                    "name": "variable.other.member.zig"
                 }
             }, 
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|(?=\\)))", 
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
             "endCaptures": {
                 "2": {
                     "name": "punctuation.separator.zig"
+                }, 
+                "3": {
+                    "name": "keyword.operator.assignment.zig"
                 }, 
                 "1": {
                     "name": "storage.type.zig"
@@ -198,7 +207,7 @@
             }, 
             "patterns": [
                 {
-                    "include": "#param_field"
+                    "include": "#param_list"
                 }, 
                 {
                     "include": "#main"
@@ -368,6 +377,31 @@
                 }
             ]
         }, 
+        "param_list": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "variable.parameter.zig"
+                }
+            }, 
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|(?=\\)))", 
+            "endCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "patterns": [
+                {
+                    "include": "#main"
+                }
+            ]
+        }, 
         "container_decl": {
             "patterns": [
                 {
@@ -414,21 +448,48 @@
                     "name": "storage.modifier.zig"
                 }
             }, 
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(=)", 
+            "end": "\\s*(=)", 
             "endCaptures": {
-                "2": {
-                    "name": "keyword.operator.assignment.zig"
-                }, 
                 "1": {
-                    "name": "storage.type.zig"
+                    "name": "keyword.operator.assignment.zig"
                 }
             }, 
             "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
             "patterns": [
                 {
                     "include": "#main"
+                }, 
+                {
+                    "match": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")", 
+                    "name": "storage.type.zig"
                 }
             ]
+        }, 
+        "function_type": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.function.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#param_list"
+                }, 
+                {
+                    "include": "#main"
+                }
+            ], 
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.parens.end.zig"
+                }
+            }, 
+            "end": "(\\))", 
+            "begin": "\\b(fn)\\s*(\\()", 
+            "contentName": "meta.parameters.zig"
         }, 
         "operators": {
             "patterns": [

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -36,19 +36,19 @@
         "container_decl": {
             "patterns": [
                 {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[({])", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])", 
                     "name": "entity.name.union.zig"
                 }, 
                 {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[({])", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[(\\{])", 
                     "name": "entity.name.struct.zig"
                 }, 
                 {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[({])", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[(\\{])", 
                     "name": "entity.name.enum.zig"
                 }, 
                 {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[({])", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])", 
                     "name": "entity.name.error.zig"
                 }, 
                 {
@@ -97,12 +97,6 @@
         "main": {
             "patterns": [
                 {
-                    "include": "#function_def"
-                }, 
-                {
-                    "include": "#function"
-                }, 
-                {
                     "include": "#label"
                 }, 
                 {
@@ -140,6 +134,12 @@
                 }, 
                 {
                     "include": "#block"
+                }, 
+                {
+                    "include": "#function_def"
+                }, 
+                {
+                    "include": "#function_call"
                 }
             ]
         }, 
@@ -154,30 +154,40 @@
                     "name": "punctuation.terminator.zig"
                 }, 
                 {
-                    "end": "(\\))", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ], 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.parens.end.zig"
-                        }
-                    }, 
-                    "begin": "(\\()", 
-                    "beginCaptures": {
-                        "1": {
-                            "name": "punctuation.section.parens.begin.zig"
-                        }
-                    }, 
-                    "contentName": "meta.group.zig"
+                    "match": "(\\()", 
+                    "name": "punctuation.section.parens.begin.zig"
+                }, 
+                {
+                    "match": "(\\))", 
+                    "name": "punctuation.section.parens.end.zig"
                 }
             ]
         }, 
         "function_def": {
-            "match": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
-            "name": "entity.name.function"
+            "end": "(\\))", 
+            "patterns": [
+                {
+                    "include": "#param_field"
+                }, 
+                {
+                    "include": "#main"
+                }
+            ], 
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }
+            }, 
+            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.function"
+                }, 
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }
+            }, 
+            "contentName": "meta.function.parameters.zig"
         }, 
         "label": {
             "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
@@ -193,9 +203,30 @@
                 }
             }
         }, 
-        "function": {
-            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
-            "name": "variable.function.zig"
+        "param_field": {
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|(?=\\)))", 
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "beginCaptures": {
+                "1": {
+                    "name": "variable.parameter.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#main"
+                }
+            ]
         }, 
         "strings": {
             "patterns": [
@@ -260,7 +291,7 @@
         "storage": {
             "patterns": [
                 {
-                    "match": "\\b(bool|void|noreturn|type|anyerror|promise)\\b", 
+                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe)\\b", 
                     "name": "storage.type.zig"
                 }, 
                 {
@@ -298,28 +329,12 @@
                 {
                     "match": "\\berror\\b", 
                     "name": "storage.type.error.zig"
-                }, 
-                {
-                    "match": "(?:(\\*+)\\s*(const|allowzero|volatile)\\b|(\\*+)|(\\?+))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?", 
-                    "captures": {
-                        "1": {
-                            "name": "keyword.operator.other.zig"
-                        }, 
-                        "3": {
-                            "name": "keyword.operator.other.zig"
-                        }, 
-                        "2": {
-                            "name": "storage.modifier.zig"
-                        }, 
-                        "5": {
-                            "name": "storage.type.zig"
-                        }, 
-                        "4": {
-                            "name": "keyword.operator.other.zig"
-                        }
-                    }
                 }
             ]
+        }, 
+        "function_call": {
+            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
+            "name": "variable.function.zig"
         }, 
         "character_escapes": {
             "patterns": [
@@ -376,7 +391,7 @@
                     "name": "keyword.operator.assignment.zig"
                 }, 
                 {
-                    "match": "((?:\\+|-|(?<=[a-zA-Z_]|@\\\")\\s*\\*)\\%?|/(?!/)|%)", 
+                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)", 
                     "name": "keyword.operator.arithmetic.zig"
                 }, 
                 {

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -1,72 +1,5 @@
 {
-    "scopeName": "source.zig", 
-    "patterns": [
-        {
-            "include": "#main"
-        }
-    ], 
-    "fileTypes": [
-        "zig"
-    ], 
     "repository": {
-        "keywords": {
-            "patterns": [
-                {
-                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b", 
-                    "name": "keyword.control.zig"
-                }, 
-                {
-                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b", 
-                    "name": "keyword.control.async.zig"
-                }, 
-                {
-                    "match": "\\b(if|else|switch|try|catch|orelse)\\b", 
-                    "name": "keyword.control.conditional.zig"
-                }, 
-                {
-                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b", 
-                    "name": "keyword.control.import.zig"
-                }, 
-                {
-                    "match": "\\b(usingnamespace|use)\\b", 
-                    "name": "keyword.other.usingnamespace.zig"
-                }
-            ]
-        }, 
-        "container_decl": {
-            "patterns": [
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])", 
-                    "name": "entity.name.union.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])", 
-                    "name": "entity.name.struct.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])", 
-                    "name": "entity.name.enum.zig"
-                }, 
-                {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])", 
-                    "name": "entity.name.error.zig"
-                }, 
-                {
-                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")", 
-                    "captures": {
-                        "1": {
-                            "name": "storage.type.error.zig"
-                        }, 
-                        "3": {
-                            "name": "entity.name.error.zig"
-                        }, 
-                        "2": {
-                            "name": "punctuation.accessor.zig"
-                        }
-                    }
-                }
-            ]
-        }, 
         "comments": {
             "patterns": [
                 {
@@ -74,28 +7,27 @@
                     "name": "comment.line.todo.zig"
                 }, 
                 {
+                    "name": "comment.line.zig", 
                     "end": "$\\n?", 
                     "begin": "//[^/]", 
                     "patterns": [
                         {
                             "include": "#todo"
                         }
-                    ], 
-                    "name": "comment.line.zig"
+                    ]
                 }, 
                 {
+                    "name": "comment.line.documentation.zig", 
                     "end": "$\\n?", 
-                    "begin": "///", 
-                    "name": "comment.line.documentation.zig"
+                    "begin": "///"
                 }
             ]
         }, 
-        "support": {
-            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b", 
-            "name": "support.function.zig"
-        }, 
         "main": {
             "patterns": [
+                {
+                    "include": "#var_decl"
+                }, 
                 {
                     "include": "#label"
                 }, 
@@ -136,35 +68,134 @@
                     "include": "#block"
                 }, 
                 {
-                    "include": "#function_def"
+                    "include": "#function_call"
                 }, 
                 {
-                    "include": "#function_call"
+                    "include": "#function_def"
                 }
             ]
         }, 
-        "punctuation": {
+        "support": {
+            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b", 
+            "name": "support.function.zig"
+        }, 
+        "block": {
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.section.braces.begin.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
             "patterns": [
                 {
-                    "match": ",", 
+                    "include": "#main"
+                }
+            ], 
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.braces.end.zig"
+                }
+            }, 
+            "end": "(\\})", 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
+            "contentName": "meta.block.zig"
+        }, 
+        "param_field": {
+            "beginCaptures": {
+                "2": {
                     "name": "punctuation.separator.zig"
                 }, 
+                "1": {
+                    "name": "variable.parameter.zig"
+                }
+            }, 
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|(?=\\)))", 
+            "endCaptures": {
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "patterns": [
                 {
-                    "match": ";", 
-                    "name": "punctuation.terminator.zig"
+                    "include": "#main"
+                }
+            ]
+        }, 
+        "keywords": {
+            "patterns": [
+                {
+                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b", 
+                    "name": "keyword.control.zig"
                 }, 
                 {
-                    "match": "(\\()", 
-                    "name": "punctuation.section.parens.begin.zig"
+                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b", 
+                    "name": "keyword.control.async.zig"
                 }, 
                 {
-                    "match": "(\\))", 
-                    "name": "punctuation.section.parens.end.zig"
+                    "match": "\\b(if|else|switch|try|catch|orelse)\\b", 
+                    "name": "keyword.control.conditional.zig"
+                }, 
+                {
+                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b", 
+                    "name": "keyword.control.import.zig"
+                }, 
+                {
+                    "match": "\\b(usingnamespace|use)\\b", 
+                    "name": "keyword.other.usingnamespace.zig"
+                }
+            ]
+        }, 
+        "character_escapes": {
+            "patterns": [
+                {
+                    "match": "\\\\n", 
+                    "name": "constant.character.escape.newline.zig"
+                }, 
+                {
+                    "match": "\\\\r", 
+                    "name": "constant.character.escape.carrigereturn.zig"
+                }, 
+                {
+                    "match": "\\\\t", 
+                    "name": "constant.character.escape.tabulator.zig"
+                }, 
+                {
+                    "match": "\\\\\\\\", 
+                    "name": "constant.character.escape.backslash.zig"
+                }, 
+                {
+                    "match": "\\\\'", 
+                    "name": "constant.character.escape.single-quote.zig"
+                }, 
+                {
+                    "match": "\\\\\\\"", 
+                    "name": "constant.character.escape.double-quote.zig"
+                }, 
+                {
+                    "match": "\\\\x[a-fA-F0-9]{2}", 
+                    "name": "constant.character.escape.hexidecimal.zig"
+                }, 
+                {
+                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}", 
+                    "name": "constant.character.escape.hexidecimal.zig"
                 }
             ]
         }, 
         "function_def": {
-            "end": "(\\))", 
+            "beginCaptures": {
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }, 
+                "1": {
+                    "name": "entity.name.function"
+                }
+            }, 
             "patterns": [
                 {
                     "include": "#param_field"
@@ -178,115 +209,45 @@
                     "name": "punctuation.section.parens.begin.zig"
                 }
             }, 
+            "end": "(\\))", 
             "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
-            "beginCaptures": {
-                "1": {
-                    "name": "entity.name.function"
-                }, 
-                "2": {
-                    "name": "punctuation.section.parens.begin.zig"
-                }
-            }, 
             "contentName": "meta.function.parameters.zig"
         }, 
-        "label": {
-            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
-            "captures": {
-                "1": {
-                    "name": "keyword.control.zig"
-                }, 
-                "3": {
-                    "name": "entity.name.label.zig"
-                }, 
-                "2": {
-                    "name": "entity.name.label.zig"
-                }
-            }
-        }, 
-        "param_field": {
-            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?:(,)|(?=\\)))", 
-            "endCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "beginCaptures": {
-                "1": {
-                    "name": "variable.parameter.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }
-            }, 
+        "constants": {
             "patterns": [
                 {
-                    "include": "#main"
+                    "match": "\\b(null|undefined|true|false)\\b", 
+                    "name": "constant.language.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.hexadecimal.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.octal.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.binary.zig"
+                }, 
+                {
+                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b", 
+                    "name": "constant.numeric.float.zig"
+                }, 
+                {
+                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b", 
+                    "name": "constant.numeric.float.hexadecimal.zig"
                 }
             ]
         }, 
-        "strings": {
-            "patterns": [
-                {
-                    "end": "\\'", 
-                    "begin": "\\'", 
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "match": "\\\\[^\\'][^\\']*?", 
-                            "name": "invalid.illegal.character.zig"
-                        }
-                    ], 
-                    "name": "string.quoted.single.zig"
-                }, 
-                {
-                    "end": "\\\"", 
-                    "begin": "c?\\\"", 
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "match": "\\\\[^\\'][^\\']*?", 
-                            "name": "invalid.illegal.character.zig"
-                        }
-                    ], 
-                    "name": "string.quoted.double.zig"
-                }, 
-                {
-                    "end": "$\\n?", 
-                    "begin": "c?\\\\\\\\", 
-                    "name": "string.quoted.other.zig"
-                }
-            ]
-        }, 
-        "block": {
-            "end": "(\\})", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ], 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.braces.end.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.section.braces.begin.zig"
-                }
-            }, 
-            "contentName": "meta.block.zig"
+        "storage_modifier": {
+            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b", 
+            "name": "storage.modifier.zig"
         }, 
         "storage": {
             "patterns": [
@@ -332,43 +293,140 @@
                 }
             ]
         }, 
+        "label": {
+            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
+            "captures": {
+                "2": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "3": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "1": {
+                    "name": "keyword.control.zig"
+                }
+            }
+        }, 
         "function_call": {
             "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
             "name": "variable.function.zig"
         }, 
-        "character_escapes": {
+        "strings": {
             "patterns": [
                 {
-                    "match": "\\\\n", 
-                    "name": "constant.character.escape.newline.zig"
+                    "name": "string.quoted.single.zig", 
+                    "end": "\\'", 
+                    "begin": "\\'", 
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "match": "\\\\[^\\'][^\\']*?", 
+                            "name": "invalid.illegal.character.zig"
+                        }
+                    ]
                 }, 
                 {
-                    "match": "\\\\r", 
-                    "name": "constant.character.escape.carrigereturn.zig"
+                    "name": "string.quoted.double.zig", 
+                    "end": "\\\"", 
+                    "begin": "c?\\\"", 
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "match": "\\\\[^\\'][^\\']*?", 
+                            "name": "invalid.illegal.character.zig"
+                        }
+                    ]
                 }, 
                 {
-                    "match": "\\\\t", 
-                    "name": "constant.character.escape.tabulator.zig"
+                    "name": "string.quoted.other.zig", 
+                    "end": "$\\n?", 
+                    "begin": "c?\\\\\\\\"
+                }
+            ]
+        }, 
+        "punctuation": {
+            "patterns": [
+                {
+                    "match": ",", 
+                    "name": "punctuation.separator.zig"
                 }, 
                 {
-                    "match": "\\\\\\\\", 
-                    "name": "constant.character.escape.backslash.zig"
+                    "match": ";", 
+                    "name": "punctuation.terminator.zig"
                 }, 
                 {
-                    "match": "\\\\'", 
-                    "name": "constant.character.escape.single-quote.zig"
+                    "match": "(\\()", 
+                    "name": "punctuation.section.parens.begin.zig"
                 }, 
                 {
-                    "match": "\\\\\\\"", 
-                    "name": "constant.character.escape.double-quote.zig"
+                    "match": "(\\))", 
+                    "name": "punctuation.section.parens.end.zig"
+                }
+            ]
+        }, 
+        "container_decl": {
+            "patterns": [
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[(\\{])", 
+                    "name": "entity.name.union.zig"
                 }, 
                 {
-                    "match": "\\\\x[a-fA-F0-9]{2}", 
-                    "name": "constant.character.escape.hexidecimal.zig"
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])", 
+                    "name": "entity.name.struct.zig"
                 }, 
                 {
-                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}", 
-                    "name": "constant.character.escape.hexidecimal.zig"
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])", 
+                    "name": "entity.name.enum.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[(\\{])", 
+                    "name": "entity.name.error.zig"
+                }, 
+                {
+                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")", 
+                    "captures": {
+                        "2": {
+                            "name": "punctuation.accessor.zig"
+                        }, 
+                        "3": {
+                            "name": "entity.name.error.zig"
+                        }, 
+                        "1": {
+                            "name": "storage.type.error.zig"
+                        }
+                    }
+                }
+            ]
+        }, 
+        "var_decl": {
+            "beginCaptures": {
+                "2": {
+                    "name": "variable.other.zig"
+                }, 
+                "3": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "1": {
+                    "name": "storage.modifier.zig"
+                }
+            }, 
+            "end": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(=)", 
+            "endCaptures": {
+                "2": {
+                    "name": "keyword.operator.assignment.zig"
+                }, 
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
+            "patterns": [
+                {
+                    "include": "#main"
                 }
             ]
         }, 
@@ -403,43 +461,16 @@
                     "name": "keyword.operator.other.zig"
                 }
             ]
-        }, 
-        "storage_modifier": {
-            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b", 
-            "name": "storage.modifier.zig"
-        }, 
-        "constants": {
-            "patterns": [
-                {
-                    "match": "\\b(null|undefined|true|false)\\b", 
-                    "name": "constant.language.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.hexadecimal.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.octal.zig"
-                }, 
-                {
-                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b", 
-                    "name": "constant.numeric.integer.binary.zig"
-                }, 
-                {
-                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b", 
-                    "name": "constant.numeric.float.zig"
-                }, 
-                {
-                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b", 
-                    "name": "constant.numeric.float.hexadecimal.zig"
-                }
-            ]
         }
     }, 
-    "name": "Zig"
+    "name": "Zig", 
+    "scopeName": "source.zig", 
+    "fileTypes": [
+        "zig"
+    ], 
+    "patterns": [
+        {
+            "include": "#main"
+        }
+    ]
 }

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -40,11 +40,11 @@
                     "name": "entity.name.union.zig"
                 }, 
                 {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[(\\{])", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:struct)\\s*[(\\{])", 
                     "name": "entity.name.struct.zig"
                 }, 
                 {
-                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[(\\{])", 
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum)\\s*[(\\{])", 
                     "name": "entity.name.enum.zig"
                 }, 
                 {

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -1,117 +1,106 @@
 {
     "scopeName": "source.zig", 
+    "patterns": [
+        {
+            "include": "#main"
+        }
+    ], 
     "fileTypes": [
         "zig"
     ], 
-    "name": "Zig", 
     "repository": {
-        "block": {
-            "contentName": "meta.block.zig", 
-            "end": "(\\})", 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.braces.end.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
+        "keywords": {
             "patterns": [
                 {
-                    "include": "#main"
-                }
-            ], 
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
+                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b", 
+                    "name": "keyword.control.zig"
                 }, 
-                "2": {
-                    "name": "punctuation.section.braces.begin.zig"
+                {
+                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b", 
+                    "name": "keyword.control.async.zig"
+                }, 
+                {
+                    "match": "\\b(if|else|switch|try|catch|orelse)\\b", 
+                    "name": "keyword.control.conditional.zig"
+                }, 
+                {
+                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b", 
+                    "name": "keyword.control.import.zig"
+                }, 
+                {
+                    "match": "\\b(usingnamespace|use)\\b", 
+                    "name": "keyword.other.usingnamespace.zig"
                 }
-            }
+            ]
+        }, 
+        "container_decl": {
+            "patterns": [
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:union)\\s*[({])", 
+                    "name": "entity.name.union.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[({])", 
+                    "name": "entity.name.struct.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:(?:extern|packed)\\s+)?(?:enum|struct|union)\\s*[({])", 
+                    "name": "entity.name.enum.zig"
+                }, 
+                {
+                    "match": "\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")(?=\\s*=\\s*(?:error)\\s*[({])", 
+                    "name": "entity.name.error.zig"
+                }, 
+                {
+                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")", 
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.error.zig"
+                        }, 
+                        "3": {
+                            "name": "entity.name.error.zig"
+                        }, 
+                        "2": {
+                            "name": "punctuation.accessor.zig"
+                        }
+                    }
+                }
+            ]
+        }, 
+        "comments": {
+            "patterns": [
+                {
+                    "match": "TODO", 
+                    "name": "comment.line.todo.zig"
+                }, 
+                {
+                    "end": "$\\n?", 
+                    "begin": "//[^/]", 
+                    "patterns": [
+                        {
+                            "include": "#todo"
+                        }
+                    ], 
+                    "name": "comment.line.zig"
+                }, 
+                {
+                    "end": "$\\n?", 
+                    "begin": "///", 
+                    "name": "comment.line.documentation.zig"
+                }
+            ]
+        }, 
+        "support": {
+            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b", 
+            "name": "support.function.zig"
         }, 
         "main": {
             "patterns": [
                 {
-                    "contentName": "meta.parameters.zig", 
-                    "end": "(\\))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.parens.end.zig"
-                        }, 
-                        "2": {
-                            "name": "storage.type.zig"
-                        }
-                    }, 
-                    "begin": "\\b(fn)(\\()", 
-                    "patterns": [
-                        {
-                            "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(,)?", 
-                            "captures": {
-                                "1": {
-                                    "name": "storage.type.zig"
-                                }, 
-                                "2": {
-                                    "name": "punctuation.separator.zig"
-                                }
-                            }
-                        }
-                    ], 
-                    "beginCaptures": {
-                        "1": {
-                            "name": "storage.type.function.zig"
-                        }, 
-                        "2": {
-                            "name": "punctuation.section.parens.begin.zig"
-                        }
-                    }
+                    "include": "#function_def"
                 }, 
                 {
-                    "contentName": "meta.function.parameters.zig", 
-                    "end": "(?<=\\))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "storage.type.zig"
-                        }
-                    }, 
-                    "begin": "\\b(fn)\\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(\\()", 
-                    "patterns": [
-                        {
-                            "include": "#param_list"
-                        }
-                    ], 
-                    "beginCaptures": {
-                        "1": {
-                            "name": "storage.type.function.zig"
-                        }, 
-                        "3": {
-                            "name": "punctuation.section.parens.begin.zig"
-                        }, 
-                        "2": {
-                            "name": "entity.name.function.zig"
-                        }
-                    }
-                }, 
-                {
-                    "match": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")\\s*(:)\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")\\s*(=)", 
-                    "captures": {
-                        "5": {
-                            "name": "keyword.operator.assignment.zig"
-                        }, 
-                        "4": {
-                            "name": "storage.type.zig"
-                        }, 
-                        "1": {
-                            "name": "storage.modifier.zig"
-                        }, 
-                        "3": {
-                            "name": "punctuation.terminator.zig"
-                        }, 
-                        "2": {
-                            "name": "variable.other.zig"
-                        }
-                    }
-                }, 
-                {
-                    "include": "#func_call"
+                    "include": "#function"
                 }, 
                 {
                     "include": "#label"
@@ -154,226 +143,63 @@
                 }
             ]
         }, 
-        "param_list": {
-            "contentName": "storage.type.zig", 
-            "end": "(?:(,)|(?:\\)))", 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.section.parens.end.zig"
-                }
-            }, 
-            "begin": "(comptime|noalias)?\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ], 
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.modifier.zig"
-                }, 
-                "3": {
-                    "name": "punctuation.terminator.zig"
-                }, 
-                "2": {
-                    "name": "variable.parameter.zig"
-                }
-            }
-        }, 
-        "storage_modifier": {
-            "name": "storage.modifier.zig", 
-            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b"
-        }, 
-        "constants": {
-            "patterns": [
-                {
-                    "name": "constant.language.zig", 
-                    "match": "\\b(null|undefined|true|false)\\b"
-                }, 
-                {
-                    "name": "constant.numeric.integer.zig", 
-                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b"
-                }, 
-                {
-                    "name": "constant.numeric.integer.hexadecimal.zig", 
-                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b"
-                }, 
-                {
-                    "name": "constant.numeric.integer.octal.zig", 
-                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b"
-                }, 
-                {
-                    "name": "constant.numeric.integer.binary.zig", 
-                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b"
-                }, 
-                {
-                    "name": "constant.numeric.float.zig", 
-                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b"
-                }, 
-                {
-                    "name": "constant.numeric.float.hexadecimal.zig", 
-                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b"
-                }
-            ]
-        }, 
-        "keywords": {
-            "patterns": [
-                {
-                    "name": "keyword.control.zig", 
-                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b"
-                }, 
-                {
-                    "name": "keyword.control.async.zig", 
-                    "match": "\\b(async|await|suspend|resume|cancel)\\b"
-                }, 
-                {
-                    "name": "keyword.control.conditional.zig", 
-                    "match": "\\b(if|else|switch|try|catch|orelse)\\b"
-                }, 
-                {
-                    "name": "keyword.control.import.zig", 
-                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b"
-                }, 
-                {
-                    "name": "keyword.other.usingnamespace.zig", 
-                    "match": "\\busingnamespace\\b"
-                }, 
-                {
-                    "name": "keyword.other.test.zig", 
-                    "match": "\\btest\\b"
-                }
-            ]
-        }, 
-        "character_escapes": {
-            "patterns": [
-                {
-                    "name": "constant.character.escape.newline.zig", 
-                    "match": "\\\\n"
-                }, 
-                {
-                    "name": "constant.character.escape.carrigereturn.zig", 
-                    "match": "\\\\r"
-                }, 
-                {
-                    "name": "constant.character.escape.tabulator.zig", 
-                    "match": "\\\\t"
-                }, 
-                {
-                    "name": "constant.character.escape.backslash.zig", 
-                    "match": "\\\\\\\\"
-                }, 
-                {
-                    "name": "constant.character.escape.single-quote.zig", 
-                    "match": "\\\\'"
-                }, 
-                {
-                    "name": "constant.character.escape.double-quote.zig", 
-                    "match": "\\\\\\\""
-                }, 
-                {
-                    "name": "constant.character.escape.hexidecimal.zig", 
-                    "match": "\\\\x[a-fA-F0-9]{2}"
-                }, 
-                {
-                    "name": "constant.character.escape.hexidecimal.zig", 
-                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}"
-                }
-            ]
-        }, 
-        "comments": {
-            "patterns": [
-                {
-                    "name": "comment.line.todo.zig", 
-                    "match": "TODO"
-                }, 
-                {
-                    "name": "comment.line.zig", 
-                    "end": "$\\n?", 
-                    "begin": "//[^/]", 
-                    "patterns": [
-                        {
-                            "include": "#todo"
-                        }
-                    ]
-                }, 
-                {
-                    "name": "comment.line.documentation.zig", 
-                    "end": "$\\n?", 
-                    "begin": "///"
-                }
-            ]
-        }, 
-        "operators": {
-            "patterns": [
-                {
-                    "name": "keyword.operator.zig", 
-                    "match": "\\b!\\b"
-                }, 
-                {
-                    "name": "keyword.operator.logical.zig", 
-                    "match": "(==|(?:!|>|<)=?)"
-                }, 
-                {
-                    "name": "keyword.operator.word.zig", 
-                    "match": "\\b(and|or)\\b"
-                }, 
-                {
-                    "name": "keyword.operator.assignment.zig", 
-                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)"
-                }, 
-                {
-                    "name": "keyword.operator.arithmetic.zig", 
-                    "match": "((?:\\+|-|(?<=\\w)\\s*\\*)\\%?|/(?!/)|%)"
-                }, 
-                {
-                    "name": "keyword.operator.bitwise.zig", 
-                    "match": "(<<|>>|&(?=\\W)|\\|(?=[^\\|])|\\^|~)"
-                }, 
-                {
-                    "name": "keyword.operator.other.zig", 
-                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=\\w)|\\?|\\|\\||\\.\\.|\\.\\.\\.)"
-                }
-            ]
-        }, 
         "punctuation": {
             "patterns": [
                 {
-                    "name": "punctuation.separator.zig", 
-                    "match": ","
+                    "match": ",", 
+                    "name": "punctuation.separator.zig"
                 }, 
                 {
-                    "name": "punctuation.terminator.zig", 
-                    "match": ";"
+                    "match": ";", 
+                    "name": "punctuation.terminator.zig"
                 }, 
                 {
-                    "contentName": "meta.group.zig", 
                     "end": "(\\))", 
+                    "patterns": [
+                        {
+                            "include": "#main"
+                        }
+                    ], 
                     "endCaptures": {
                         "1": {
                             "name": "punctuation.section.parens.end.zig"
                         }
                     }, 
                     "begin": "(\\()", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ], 
                     "beginCaptures": {
                         "1": {
                             "name": "punctuation.section.parens.begin.zig"
                         }
-                    }
+                    }, 
+                    "contentName": "meta.group.zig"
                 }
             ]
+        }, 
+        "function_def": {
+            "match": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
+            "name": "entity.name.function"
+        }, 
+        "label": {
+            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
+            "captures": {
+                "1": {
+                    "name": "keyword.control.zig"
+                }, 
+                "3": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "2": {
+                    "name": "entity.name.label.zig"
+                }
+            }
+        }, 
+        "function": {
+            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()", 
+            "name": "variable.function.zig"
         }, 
         "strings": {
             "patterns": [
                 {
-                    "name": "string.quoted.single.zig", 
                     "end": "\\'", 
                     "begin": "\\'", 
                     "patterns": [
@@ -381,13 +207,13 @@
                             "include": "#character_escapes"
                         }, 
                         {
-                            "name": "invalid.illegal.character.zig", 
-                            "match": "\\\\[^\\'][^\\']*?"
+                            "match": "\\\\[^\\'][^\\']*?", 
+                            "name": "invalid.illegal.character.zig"
                         }
-                    ]
+                    ], 
+                    "name": "string.quoted.single.zig"
                 }, 
                 {
-                    "name": "string.quoted.double.zig", 
                     "end": "\\\"", 
                     "begin": "c?\\\"", 
                     "patterns": [
@@ -395,285 +221,210 @@
                             "include": "#character_escapes"
                         }, 
                         {
-                            "name": "invalid.illegal.character.zig", 
-                            "match": "\\\\[^\\'][^\\']*?"
+                            "match": "\\\\[^\\'][^\\']*?", 
+                            "name": "invalid.illegal.character.zig"
                         }
-                    ]
+                    ], 
+                    "name": "string.quoted.double.zig"
                 }, 
                 {
-                    "name": "string.quoted.other.zig", 
                     "end": "$\\n?", 
-                    "begin": "c?\\\\\\\\"
+                    "begin": "c?\\\\\\\\", 
+                    "name": "string.quoted.other.zig"
                 }
             ]
         }, 
-        "func_call": {
-            "contentName": "meta.function-call.zig", 
-            "end": "(\\))", 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.parens.end.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_]\\w*|@\\\".+\\\")(\\()", 
+        "block": {
+            "end": "(\\})", 
             "patterns": [
                 {
                     "include": "#main"
-                }, 
-                {
-                    "match": "(?:(,)|(?:\\)))", 
-                    "captures": {
-                        "1": {
-                            "name": "punctuation.separator.zig"
-                        }, 
-                        "2": {
-                            "name": "punctuation.section.parens.end.zig"
-                        }
-                    }
                 }
             ], 
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.braces.end.zig"
+                }
+            }, 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
             "beginCaptures": {
                 "1": {
-                    "name": "variable.function.zig"
+                    "name": "storage.type.zig"
                 }, 
                 "2": {
-                    "name": "punctuation.section.parens.begin.zig"
+                    "name": "punctuation.section.braces.begin.zig"
                 }
-            }
+            }, 
+            "contentName": "meta.block.zig"
         }, 
         "storage": {
             "patterns": [
                 {
-                    "name": "storage.type.zig", 
-                    "match": "\\b(bool|void|noreturn|type|anyerror|promise)\\b"
+                    "match": "\\b(bool|void|noreturn|type|anyerror|promise)\\b", 
+                    "name": "storage.type.zig"
                 }, 
                 {
-                    "name": "storage.type.integer.zig", 
-                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b"
+                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b", 
+                    "name": "storage.type.integer.zig"
                 }, 
                 {
-                    "name": "storage.type.float.zig", 
-                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b"
+                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b", 
+                    "name": "storage.type.float.zig"
                 }, 
                 {
-                    "name": "storage.type.c_compat.zig", 
-                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b"
-                }
-            ]
-        }, 
-        "support": {
-            "name": "support.function.zig", 
-            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b"
-        }, 
-        "label": {
-            "patterns": [
-                {
-                    "name": "entity.name.label.zig", 
-                    "match": "(?<!\\w):([a-zA-Z_]\\w*|@\\\".+\\\")"
+                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b", 
+                    "name": "storage.type.c_compat.zig"
                 }, 
                 {
-                    "beginCaptures": {
-                        "1": {
-                            "name": "entity.name.label.zig"
-                        }, 
-                        "3": {
-                            "name": "keyword.control.zig"
-                        }, 
-                        "2": {
-                            "name": "punctuation.section.braces.begin.zig"
-                        }
-                    }, 
-                    "end": "(})", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.braces.end.zig"
-                        }
-                    }, 
-                    "begin": "([a-zA-Z_]\\w*|@\\\".+\\\"):\\s*(?:({)|(while|for))", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ]
-                }
-            ]
-        }, 
-        "container_decl": {
-            "patterns": [
-                {
-                    "contentName": "meta.union", 
-                    "end": "(})", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.braces.end.zig"
-                        }
-                    }, 
-                    "begin": "(?:([a-zA-Z_]\\w*|@\\\".+\\\")\\s*=\\s*)?\\b(packed|extern)?\\b\\s*(union\\b)(?:(\\()([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(\\)))?\\s*({)", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ], 
-                    "beginCaptures": {
-                        "5": {
-                            "name": "storage.type.zig"
-                        }, 
-                        "4": {
-                            "name": "punctuation.section.parens.begin.zig"
-                        }, 
-                        "7": {
-                            "name": "punctuation.section.braces.begin.zig"
-                        }, 
-                        "6": {
-                            "name": "punctuation.section.parens.end.zig"
-                        }, 
-                        "1": {
-                            "name": "entity.name.union.zig"
-                        }, 
-                        "3": {
-                            "name": "storage.type.union.zig"
-                        }, 
-                        "2": {
-                            "name": "storage.modifier.zig"
-                        }
-                    }
+                    "match": "\\bfn\\b", 
+                    "name": "storage.type.function.zig"
                 }, 
                 {
-                    "contentName": "meta.struct.zig", 
-                    "end": "(})", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.braces.end.zig"
-                        }
-                    }, 
-                    "begin": "(?:([a-zA-Z_]\\w*|@\\\".+\\\")\\s*=\\s*)?\\b(packed|extern)?\\b\\s*(struct)\\s*({)", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ], 
-                    "beginCaptures": {
-                        "4": {
-                            "name": "punctuation.section.braces.begin.zig"
-                        }, 
-                        "1": {
-                            "name": "entity.name.struct.zig"
-                        }, 
-                        "3": {
-                            "name": "storage.type.struct.zig"
-                        }, 
-                        "2": {
-                            "name": "storage.modifier.zig"
-                        }
-                    }
+                    "match": "\\btest\\b", 
+                    "name": "storage.type.test.zig"
                 }, 
                 {
-                    "contentName": "meta.enum.zig", 
-                    "end": "(})", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.braces.end.zig"
-                        }
-                    }, 
-                    "begin": "(?:([a-zA-Z_]\\w*|@\\\".+\\\")\\s*=\\s*)?\\b(extern)?\\b\\s*(enum\\b)(?:(\\()([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(\\)))?\\s*({)", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ], 
-                    "beginCaptures": {
-                        "5": {
-                            "name": "storage.type.zig"
-                        }, 
-                        "4": {
-                            "name": "punctuation.section.parens.begin.zig"
-                        }, 
-                        "7": {
-                            "name": "punctuation.section.braces.begin.zig"
-                        }, 
-                        "6": {
-                            "name": "punctuation.section.parens.end.zig"
-                        }, 
-                        "1": {
-                            "name": "entity.name.enum.zig"
-                        }, 
-                        "3": {
-                            "name": "storage.type.enum.zig"
-                        }, 
-                        "2": {
-                            "name": "storage.modifier.zig"
-                        }
-                    }
+                    "match": "\\bstruct\\b", 
+                    "name": "storage.type.struct.zig"
                 }, 
                 {
-                    "contentName": "meta.error.zig", 
-                    "end": "(})", 
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.section.braces.end.zig"
-                        }
-                    }, 
-                    "begin": "(?:([a-zA-Z_]\\w*|@\\\".+\\\")\\s*=\\s*)?\\b(error)\\b\\s*({)", 
-                    "patterns": [
-                        {
-                            "include": "#main"
-                        }
-                    ], 
-                    "beginCaptures": {
-                        "1": {
-                            "name": "entity.name.error.zig"
-                        }, 
-                        "3": {
-                            "name": "punctuation.section.braces.begin.zig"
-                        }, 
-                        "2": {
-                            "name": "storage.type.error.zig"
-                        }
-                    }
+                    "match": "\\benum\\b", 
+                    "name": "storage.type.enum.zig"
                 }, 
                 {
-                    "match": "\\b(error)(\\.)([a-zA-Z_]\\w*|@\\\".+\\\")", 
+                    "match": "\\bunion\\b", 
+                    "name": "storage.type.union.zig"
+                }, 
+                {
+                    "match": "\\berror\\b", 
+                    "name": "storage.type.error.zig"
+                }, 
+                {
+                    "match": "(?:(\\*+)\\s*(const|allowzero|volatile)\\b|(\\*+)|(\\?+))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?", 
                     "captures": {
                         "1": {
-                            "name": "storage.type.error.zig"
+                            "name": "keyword.operator.other.zig"
                         }, 
                         "3": {
-                            "name": "entity.name.error.zig"
+                            "name": "keyword.operator.other.zig"
                         }, 
                         "2": {
-                            "name": "punctuation.accessor.zig"
+                            "name": "storage.modifier.zig"
+                        }, 
+                        "5": {
+                            "name": "storage.type.zig"
+                        }, 
+                        "4": {
+                            "name": "keyword.operator.other.zig"
                         }
                     }
                 }
             ]
         }, 
-        "field_decl": {
-            "contentName": "storage.type.zig", 
-            "end": "(?:(,)|(?:\\n|\\r))", 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.separator.zig"
-                }
-            }, 
-            "begin": "([a-zA-Z_]\\w*|@\\\".+\\\")\\s*(:)\\s*", 
+        "character_escapes": {
             "patterns": [
                 {
-                    "include": "#main"
-                }
-            ], 
-            "beginCaptures": {
-                "1": {
-                    "name": "variable.other.member.zig"
+                    "match": "\\\\n", 
+                    "name": "constant.character.escape.newline.zig"
                 }, 
-                "2": {
-                    "name": "punctuation.terminator.zig"
+                {
+                    "match": "\\\\r", 
+                    "name": "constant.character.escape.carrigereturn.zig"
+                }, 
+                {
+                    "match": "\\\\t", 
+                    "name": "constant.character.escape.tabulator.zig"
+                }, 
+                {
+                    "match": "\\\\\\\\", 
+                    "name": "constant.character.escape.backslash.zig"
+                }, 
+                {
+                    "match": "\\\\'", 
+                    "name": "constant.character.escape.single-quote.zig"
+                }, 
+                {
+                    "match": "\\\\\\\"", 
+                    "name": "constant.character.escape.double-quote.zig"
+                }, 
+                {
+                    "match": "\\\\x[a-fA-F0-9]{2}", 
+                    "name": "constant.character.escape.hexidecimal.zig"
+                }, 
+                {
+                    "match": "\\\\u\\{[a-fA-F0-9]{1,6}\\}", 
+                    "name": "constant.character.escape.hexidecimal.zig"
                 }
-            }
+            ]
+        }, 
+        "operators": {
+            "patterns": [
+                {
+                    "match": "\\b!\\b", 
+                    "name": "keyword.operator.zig"
+                }, 
+                {
+                    "match": "(==|(?:!|>|<)=?)", 
+                    "name": "keyword.operator.logical.zig"
+                }, 
+                {
+                    "match": "\\b(and|or)\\b", 
+                    "name": "keyword.operator.word.zig"
+                }, 
+                {
+                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)", 
+                    "name": "keyword.operator.assignment.zig"
+                }, 
+                {
+                    "match": "((?:\\+|-|(?<=[a-zA-Z_]|@\\\")\\s*\\*)\\%?|/(?!/)|%)", 
+                    "name": "keyword.operator.arithmetic.zig"
+                }, 
+                {
+                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)", 
+                    "name": "keyword.operator.bitwise.zig"
+                }, 
+                {
+                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})", 
+                    "name": "keyword.operator.other.zig"
+                }
+            ]
+        }, 
+        "storage_modifier": {
+            "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b", 
+            "name": "storage.modifier.zig"
+        }, 
+        "constants": {
+            "patterns": [
+                {
+                    "match": "\\b(null|undefined|true|false)\\b", 
+                    "name": "constant.language.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(-?[0-9]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0x[a-fA-F0-9]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.hexadecimal.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0o[0-7]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.octal.zig"
+                }, 
+                {
+                    "match": "\\b(?<!\\.)(0b[01]+)(?!\\.)\\b", 
+                    "name": "constant.numeric.integer.binary.zig"
+                }, 
+                {
+                    "match": "(?<!\\.)(-?\\b[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?!\\.)\\b", 
+                    "name": "constant.numeric.float.zig"
+                }, 
+                {
+                    "match": "(?<!\\.)(-?\\b0x[a-fA-F0-9]+(?:\\.[a-fA-F0-9]+)?[pP]?(?:[+-]?[0-9]+)?)(?!\\.)\\b", 
+                    "name": "constant.numeric.float.hexadecimal.zig"
+                }
+            ]
         }
     }, 
-    "patterns": [
-        {
-            "include": "#main"
-        }
-    ]
+    "name": "Zig"
 }

--- a/Syntaxes/Zig.tmLanguage.json
+++ b/Syntaxes/Zig.tmLanguage.json
@@ -1,201 +1,41 @@
 {
-    "scopeName": "source.zig", 
-    "name": "Zig", 
-    "fileTypes": [
-        "zig"
-    ], 
     "repository": {
-        "support": {
-            "name": "support.function.zig", 
-            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b"
-        }, 
-        "storage": {
+        "strings": {
             "patterns": [
                 {
-                    "name": "storage.type.zig", 
-                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe|promise)\\b"
+                    "end": "\\'", 
+                    "name": "string.quoted.single.zig", 
+                    "begin": "\\'", 
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "name": "invalid.illegal.character.zig", 
+                            "match": "\\\\[^\\'][^\\']*?"
+                        }
+                    ]
                 }, 
                 {
-                    "name": "storage.type.integer.zig", 
-                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b"
+                    "end": "\\\"", 
+                    "name": "string.quoted.double.zig", 
+                    "begin": "c?\\\"", 
+                    "patterns": [
+                        {
+                            "include": "#character_escapes"
+                        }, 
+                        {
+                            "name": "invalid.illegal.character.zig", 
+                            "match": "\\\\[^\\'][^\\']*?"
+                        }
+                    ]
                 }, 
                 {
-                    "name": "storage.type.float.zig", 
-                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b"
-                }, 
-                {
-                    "name": "storage.type.c_compat.zig", 
-                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b"
-                }, 
-                {
-                    "name": "storage.type.function.zig", 
-                    "match": "\\bfn\\b"
-                }, 
-                {
-                    "name": "storage.type.test.zig", 
-                    "match": "\\btest\\b"
-                }, 
-                {
-                    "name": "storage.type.struct.zig", 
-                    "match": "\\bstruct\\b"
-                }, 
-                {
-                    "name": "storage.type.enum.zig", 
-                    "match": "\\benum\\b"
-                }, 
-                {
-                    "name": "storage.type.union.zig", 
-                    "match": "\\bunion\\b"
-                }, 
-                {
-                    "name": "storage.type.error.zig", 
-                    "match": "\\berror\\b"
+                    "end": "$\\n?", 
+                    "name": "string.quoted.other.zig", 
+                    "begin": "c?\\\\\\\\"
                 }
             ]
-        }, 
-        "function_def": {
-            "end": "(?<=\\))([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")", 
-            "endCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "patterns": [
-                {
-                    "include": "#param_list"
-                }, 
-                {
-                    "include": "#main"
-                }, 
-                {
-                    "name": "storage.type.zig", 
-                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
-                }
-            ], 
-            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
-            "beginCaptures": {
-                "1": {
-                    "name": "entity.name.function"
-                }, 
-                "2": {
-                    "name": "punctuation.section.parens.begin.zig"
-                }
-            }
-        }, 
-        "field_decl": {
-            "end": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
-            "endCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }, 
-                "3": {
-                    "name": "keyword.operator.assignment.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }
-            }, 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ], 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "beginCaptures": {
-                "1": {
-                    "name": "variable.other.member.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }
-            }
-        }, 
-        "enum_literal": {
-            "name": "constant.language.enum", 
-            "match": "(?<!\\w)(\\.(?:[a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\"))"
-        }, 
-        "keywords": {
-            "patterns": [
-                {
-                    "name": "keyword.control.zig", 
-                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b"
-                }, 
-                {
-                    "name": "keyword.control.async.zig", 
-                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b"
-                }, 
-                {
-                    "name": "keyword.control.conditional.zig", 
-                    "match": "\\b(if|else|switch|try|catch|orelse)\\b"
-                }, 
-                {
-                    "name": "keyword.control.import.zig", 
-                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b"
-                }, 
-                {
-                    "name": "keyword.other.usingnamespace.zig", 
-                    "match": "\\b(usingnamespace|use)\\b"
-                }
-            ]
-        }, 
-        "var_decl": {
-            "end": "\\s*(=)", 
-            "endCaptures": {
-                "1": {
-                    "name": "keyword.operator.assignment.zig"
-                }
-            }, 
-            "patterns": [
-                {
-                    "include": "#main"
-                }, 
-                {
-                    "name": "storage.type.zig", 
-                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
-                }
-            ], 
-            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.modifier.zig"
-                }, 
-                "3": {
-                    "name": "punctuation.separator.zig"
-                }, 
-                "2": {
-                    "name": "variable.other.zig"
-                }
-            }
-        }, 
-        "function_type": {
-            "endCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }
-            }, 
-            "contentName": "meta.function.parameters.zig", 
-            "begin": "\\b(fn)\\s*(\\()", 
-            "end": "(?<=\\))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")", 
-            "patterns": [
-                {
-                    "include": "#param_list"
-                }, 
-                {
-                    "include": "#main"
-                }, 
-                {
-                    "name": "storage.type.zig", 
-                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
-                }
-            ], 
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.type.function.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.section.parens.begin.zig"
-                }
-            }
         }, 
         "main": {
             "patterns": [
@@ -258,9 +98,192 @@
                 }
             ]
         }, 
+        "support": {
+            "name": "support.function.zig", 
+            "match": "(?<!\\w)@[^\\\"\\d][a-zA-Z_]\\w*\\b"
+        }, 
+        "storage": {
+            "patterns": [
+                {
+                    "name": "storage.type.zig", 
+                    "match": "\\b(bool|void|noreturn|type|anyerror|anyframe)\\b"
+                }, 
+                {
+                    "name": "storage.type.integer.zig", 
+                    "match": "\\b(?<!\\.)([iu][0-9]\\d*|[iu]size|comptime_int)\\b"
+                }, 
+                {
+                    "name": "storage.type.float.zig", 
+                    "match": "\\b(f16|f32|f64|f128|comptime_float)\\b"
+                }, 
+                {
+                    "name": "storage.type.c_compat.zig", 
+                    "match": "\\b(c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void)\\b"
+                }, 
+                {
+                    "name": "storage.type.function.zig", 
+                    "match": "\\bfn\\b"
+                }, 
+                {
+                    "name": "storage.type.test.zig", 
+                    "match": "\\btest\\b"
+                }, 
+                {
+                    "name": "storage.type.struct.zig", 
+                    "match": "\\bstruct\\b"
+                }, 
+                {
+                    "name": "storage.type.enum.zig", 
+                    "match": "\\benum\\b"
+                }, 
+                {
+                    "name": "storage.type.union.zig", 
+                    "match": "\\bunion\\b"
+                }, 
+                {
+                    "name": "storage.type.error.zig", 
+                    "match": "\\berror\\b"
+                }
+            ]
+        }, 
+        "label": {
+            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
+            "captures": {
+                "1": {
+                    "name": "keyword.control.zig"
+                }, 
+                "2": {
+                    "name": "entity.name.label.zig"
+                }, 
+                "3": {
+                    "name": "entity.name.label.zig"
+                }
+            }
+        }, 
+        "operators": {
+            "patterns": [
+                {
+                    "name": "keyword.operator.zig", 
+                    "match": "\\b!\\b"
+                }, 
+                {
+                    "name": "keyword.operator.logical.zig", 
+                    "match": "(==|(?:!|>|<)=?)"
+                }, 
+                {
+                    "name": "keyword.operator.word.zig", 
+                    "match": "\\b(and|or)\\b"
+                }, 
+                {
+                    "name": "keyword.operator.assignment.zig", 
+                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)"
+                }, 
+                {
+                    "name": "keyword.operator.arithmetic.zig", 
+                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)"
+                }, 
+                {
+                    "name": "keyword.operator.bitwise.zig", 
+                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)"
+                }, 
+                {
+                    "name": "keyword.operator.other.zig", 
+                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})"
+                }
+            ]
+        }, 
+        "block": {
+            "end": "(\\})", 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.section.braces.end.zig"
+                }
+            }, 
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.section.braces.begin.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#main"
+                }
+            ]
+        }, 
         "storage_modifier": {
             "name": "storage.modifier.zig", 
             "match": "\\b(const|var|extern|packed|export|pub|noalias|inline|comptime|nakedcc|stdcallcc|volatile|align|linksection|threadlocal|allowzero)\\b"
+        }, 
+        "function_call": {
+            "name": "variable.function.zig", 
+            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()"
+        }, 
+        "enum_literal": {
+            "name": "constant.language.enum", 
+            "match": "(?<!\\w)(\\.(?:[a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\"))"
+        }, 
+        "function_type": {
+            "end": "(?<=\\))\\s*([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")", 
+            "begin": "\\b(fn)\\s*(\\()", 
+            "contentName": "meta.function.parameters.zig", 
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.function.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }
+            }, 
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#param_list"
+                }, 
+                {
+                    "include": "#main"
+                }, 
+                {
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }
+            ]
+        }, 
+        "var_decl": {
+            "end": "\\s*(=)", 
+            "begin": "\\b(const|var)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)", 
+            "endCaptures": {
+                "1": {
+                    "name": "keyword.operator.assignment.zig"
+                }
+            }, 
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.modifier.zig"
+                }, 
+                "2": {
+                    "name": "variable.other.zig"
+                }, 
+                "3": {
+                    "name": "punctuation.separator.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#main"
+                }, 
+                {
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }
+            ]
         }, 
         "constants": {
             "patterns": [
@@ -303,17 +326,45 @@
                 {
                     "end": "$\\n?", 
                     "name": "comment.line.zig", 
+                    "begin": "//[^/]", 
                     "patterns": [
                         {
                             "include": "#todo"
                         }
-                    ], 
-                    "begin": "//[^/]"
+                    ]
                 }, 
                 {
                     "end": "$\\n?", 
                     "name": "comment.line.documentation.zig", 
                     "begin": "///"
+                }
+            ]
+        }, 
+        "field_decl": {
+            "end": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")(?:(,)|\\s*(=)\\s*|(?=\\n|\\r))", 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "3": {
+                    "name": "keyword.operator.assignment.zig"
+                }
+            }, 
+            "beginCaptures": {
+                "1": {
+                    "name": "variable.other.member.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#main"
                 }
             ]
         }, 
@@ -341,156 +392,15 @@
                         "1": {
                             "name": "storage.type.error.zig"
                         }, 
-                        "3": {
-                            "name": "entity.name.error.zig"
-                        }, 
                         "2": {
                             "name": "punctuation.accessor.zig"
+                        }, 
+                        "3": {
+                            "name": "entity.name.error.zig"
                         }
                     }
                 }
             ]
-        }, 
-        "operators": {
-            "patterns": [
-                {
-                    "name": "keyword.operator.zig", 
-                    "match": "\\b!\\b"
-                }, 
-                {
-                    "name": "keyword.operator.logical.zig", 
-                    "match": "(==|(?:!|>|<)=?)"
-                }, 
-                {
-                    "name": "keyword.operator.word.zig", 
-                    "match": "\\b(and|or)\\b"
-                }, 
-                {
-                    "name": "keyword.operator.assignment.zig", 
-                    "match": "((?:(?:\\+|-|\\*)\\%?|/|%|<<|>>|&|\\|(?=[^\\|])|\\^)?=)"
-                }, 
-                {
-                    "name": "keyword.operator.arithmetic.zig", 
-                    "match": "((?:\\+|-|\\*)\\%?|/(?!/)|%)"
-                }, 
-                {
-                    "name": "keyword.operator.bitwise.zig", 
-                    "match": "(<<|>>|&(?=[a-zA-Z_]|@\\\")|\\|(?=[^\\|])|\\^|~)"
-                }, 
-                {
-                    "name": "keyword.operator.other.zig", 
-                    "match": "(\\+\\+|\\*\\*|->|\\.\\?|\\.\\*|&(?=[a-zA-Z_]|@\\\")|\\?|\\|\\||\\.{2,3})"
-                }
-            ]
-        }, 
-        "block": {
-            "end": "(\\})", 
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.section.braces.end.zig"
-                }
-            }, 
-            "patterns": [
-                {
-                    "include": "#main"
-                }
-            ], 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(\\{)", 
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.section.braces.begin.zig"
-                }
-            }
-        }, 
-        "param_list": {
-            "end": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(?:(\\))|(,))", 
-            "endCaptures": {
-                "1": {
-                    "name": "storage.type.zig"
-                }, 
-                "3": {
-                    "name": "punctuation.section.parens.end.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }
-            }, 
-            "patterns": [
-                {
-                    "name": "storage.type.zig", 
-                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
-                }, 
-                {
-                    "include": "#main"
-                }
-            ], 
-            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
-            "beginCaptures": {
-                "1": {
-                    "name": "variable.parameter.zig"
-                }, 
-                "2": {
-                    "name": "punctuation.separator.zig"
-                }
-            }
-        }, 
-        "strings": {
-            "patterns": [
-                {
-                    "end": "\\'", 
-                    "name": "string.quoted.single.zig", 
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "name": "invalid.illegal.character.zig", 
-                            "match": "\\\\[^\\'][^\\']*?"
-                        }
-                    ], 
-                    "begin": "\\'"
-                }, 
-                {
-                    "end": "\\\"", 
-                    "name": "string.quoted.double.zig", 
-                    "patterns": [
-                        {
-                            "include": "#character_escapes"
-                        }, 
-                        {
-                            "name": "invalid.illegal.character.zig", 
-                            "match": "\\\\[^\\'][^\\']*?"
-                        }
-                    ], 
-                    "begin": "c?\\\""
-                }, 
-                {
-                    "end": "$\\n?", 
-                    "name": "string.quoted.other.zig", 
-                    "begin": "c?\\\\\\\\"
-                }
-            ]
-        }, 
-        "label": {
-            "match": "\\b(break|continue)\\s*:\\s*([a-zA-Z_]\\w*|@\\\".+\\\")\\b|\\b(?!\\d)([a-zA-Z_]\\w*|@\\\".+\\\")\\b(?=\\s*:\\s*(?:\\{|while\\b))", 
-            "captures": {
-                "1": {
-                    "name": "keyword.control.zig"
-                }, 
-                "3": {
-                    "name": "entity.name.label.zig"
-                }, 
-                "2": {
-                    "name": "entity.name.label.zig"
-                }
-            }
-        }, 
-        "function_call": {
-            "name": "variable.function.zig", 
-            "match": "(?<!fn)\\b([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(?=\\s*\\()"
         }, 
         "character_escapes": {
             "patterns": [
@@ -528,6 +438,91 @@
                 }
             ]
         }, 
+        "function_def": {
+            "end": "(?<=\\))([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")", 
+            "begin": "(?<=fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")(\\()", 
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }
+            }, 
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.function"
+                }, 
+                "2": {
+                    "name": "punctuation.section.parens.begin.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "include": "#param_list"
+                }, 
+                {
+                    "include": "#main"
+                }, 
+                {
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }
+            ]
+        }, 
+        "param_list": {
+            "end": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")?\\s*(?:(\\))|(,))", 
+            "begin": "([a-zA-Z_][a-zA-Z0-9_]*|@\\\".+\\\")\\s*(:)\\s*", 
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }, 
+                "3": {
+                    "name": "punctuation.section.parens.end.zig"
+                }
+            }, 
+            "beginCaptures": {
+                "1": {
+                    "name": "variable.parameter.zig"
+                }, 
+                "2": {
+                    "name": "punctuation.separator.zig"
+                }
+            }, 
+            "patterns": [
+                {
+                    "name": "storage.type.zig", 
+                    "match": "([a-zA-Z_][a-zA-Z0-9_.]*|@\\\".+\\\")"
+                }, 
+                {
+                    "include": "#main"
+                }
+            ]
+        }, 
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "keyword.control.zig", 
+                    "match": "\\b(while|for|break|return|continue|asm|defer|errdefer|unreachable)\\b"
+                }, 
+                {
+                    "name": "keyword.control.async.zig", 
+                    "match": "\\b(noasync|async|await|suspend|resume|cancel)\\b"
+                }, 
+                {
+                    "name": "keyword.control.conditional.zig", 
+                    "match": "\\b(if|else|switch|try|catch|orelse)\\b"
+                }, 
+                {
+                    "name": "keyword.control.import.zig", 
+                    "match": "(?<!\\w)(@import|@cImport|@cInclude)\\b"
+                }, 
+                {
+                    "name": "keyword.other.usingnamespace.zig", 
+                    "match": "\\b(usingnamespace)\\b"
+                }
+            ]
+        }, 
         "punctuation": {
             "patterns": [
                 {
@@ -549,9 +544,14 @@
             ]
         }
     }, 
+    "name": "Zig", 
+    "scopeName": "source.zig", 
     "patterns": [
         {
             "include": "#main"
         }
+    ], 
+    "fileTypes": [
+        "zig"
     ]
 }

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -9,6 +9,12 @@ struct
 enum
 error
 
+fn dump(
+    value: var.asda.ad.asd,
+    // NYI some arg
+    asdasd: Baddad
+) void {
+
 
 "for"
 break return continue asm defer errdefer unreachable
@@ -25,8 +31,7 @@ fn usingnamespace test
 
 bool f16 f32 f64 f128 void noreturn type anyerror
 
-promise
-
+promise anyframe
 i2 u2 i3 u3 i4 u4 i5 u5 i6 u6 i7 u7 i8 u8 i16 u16 u29 i29 i32 u32 i64 u64 i128 u128 isize usize
 
 .i368 .i686 .i23

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -157,7 +157,7 @@ extern fn foobar() void;
 \\ adsjfafsdjkl
 
 pub fn barfoo();
-
+fn
  \\ adsjfafsdjkl
 }
 "hello \x1 \n \t \\ \r 1m ' \\ \a \" \u{11}"
@@ -288,9 +288,9 @@ const Err = error {
     : Bar,
 }
 (asdasd)
-const Bar = union {
-    field: Foo,
-    field: Bad = @This() {},
+const Bar = struct {
+    field: Foo = 234"asas",
+    field: Bad = Fasd {},
 };
 
 const Boof = union(enum) {

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -315,7 +315,9 @@ blk: {
 }
 
 extern fn f2(s: *const *volatile u8) c_int;
-var asd: asdads = 0;
+
+var asd: *const asdads = 0;
+
 blk: while () : (sas) {
 error.asdasd;
 }

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -273,7 +273,7 @@ pub extern "ole32" stdcallcc fn CoTaskMemFree(pv: *const LPVOID,        asda: as
 pub stdcallcc fn CoUninitialize() void;
 
 pub const Foo = extern struct {
-
+	fn_call()
 };
 
 extern struct {
@@ -313,7 +313,8 @@ blk: {
 
 }
 
-
+extern fn f2(s: **align(1) *const *volatile u8) c_int;
+...
 blk: while () : (sas) {
-
+error.asdasd;
 }

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -15,7 +15,7 @@ break return continue asm defer errdefer unreachable
 
 if else switch and or try catch orelse
 
-async await suspend resume cancel
+async await suspend resume cancel noasync
 
 while for
 
@@ -269,7 +269,7 @@ pub extern "hellas" export fn hello(as: as) OO {
 anyframe->U
 }
 
-pub extern "ole32" stdcallcc fn CoTaskMemFree(pv: *const LPVOID, asda: asdsad, sacz: @"zxc", asd: asd) void;
+pub extern "ole32" stdcallcc fn CoTaskMemFree(pv: *const LPVOID, asda: asdsad, sacz: @"zxc", asd: asd) oop;
 
 pub stdcallcc fn CoUninitialize() A;
 

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -314,7 +314,7 @@ blk: {
 
 }
 
-extern fn f2(comptime s: *const *volatile u8) c_int;
+extern fn f2(s: *const *volatile u8) c_int;
 
 blk: while () : (sas) {
 error.asdasd;

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -170,7 +170,7 @@ pub fn barfoo();
 '\a'
 '\aaasas'
 '\n'
-fn(i13,Foo)Bar;
+fn(i13,Foo) Bar;
 foo = bar;
 
 @"overloaded" = 89;
@@ -266,11 +266,12 @@ foo = bar;
 pub extern "hellas" export fn @"eeeasla"(as: FN) userdata;
 
 pub extern "hellas" export fn hello(as: as) OO {
-
+anyframe->U
 }
 
-pub extern "ole32" stdcallcc fn CoTaskMemFree(pv: *const LPVOID,        asda: asdsad, sacz: @"zxc", )void;
-pub stdcallcc fn CoUninitialize() void;
+pub extern "ole32" stdcallcc fn CoTaskMemFree(pv: *const LPVOID, asda: asdsad, sacz: @"zxc", asd: asd) void;
+
+pub stdcallcc fn CoUninitialize() A;
 
 pub const Foo = extern struct {
 	fn_call()
@@ -313,8 +314,8 @@ blk: {
 
 }
 
-extern fn f2(s: **align(1) *const *volatile u8) c_int;
-...
+extern fn f2(comptime s: *const *volatile u8) c_int;
+
 blk: while () : (sas) {
 error.asdasd;
 }

--- a/Syntaxes/samples.zig
+++ b/Syntaxes/samples.zig
@@ -315,7 +315,7 @@ blk: {
 }
 
 extern fn f2(s: *const *volatile u8) c_int;
-
+var asd: asdads = 0;
 blk: while () : (sas) {
 error.asdasd;
 }


### PR DESCRIPTION
this is designed to close #27 and close #28 and simplifies some of the regexes. i'll try not to merge this until i confirm it works well for most (if not all) zig code.
- introduces the `noasync` keyword
- removed `use` keywords
- removed `promise` type
- `anyframe->T` type added

TODO
- [x] highlighting for function parameters
- [x] highlighting for function calls
- [x] highlighting for function pointer types
- [x] highlighting for container fields
- [x] highlighting for types in variable declaration
- [x] highlighting for return types

~~highlighting for return types might not be implemented because i am not quite sure how to parse function prototypes and declarations and parse the return type.~~