### PR TITLE
Respect TM_ZIG environment variable

### DIFF
--- a/Commands/Fmt.tmCommand
+++ b/Commands/Fmt.tmCommand
@@ -14,7 +14,7 @@ set -e
 
 PATH=/opt/local/bin:/usr/local/bin:/usr/local/zig/bin:$PATH
         
-require_cmd zig
+require_cmd "${TM_ZIG:-zig}"
 
 tmpfile=$(mktemp "${TMPDIR:-/tmp/}zig-fmt.XXXXXX")
 cat - &gt; "$tmpfile"


### PR DESCRIPTION
The argument passed to `require_cmd` did not respect the TM_ZIG
environment variable.