### PR TITLE
Add language grammar keyboard shortcut

### DIFF
--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -6,6 +6,8 @@
 	<array>
 		<string>zig</string>
 	</array>
+	<key>keyEquivalent</key>
+	<string>^~Z</string>
 	<key>name</key>
 	<string>Zig</string>
 	<key>patterns</key>


### PR DESCRIPTION
In TextMate, you can usually press `shift+ctrl+<letter>` where `<letter>` is the starting letter of the grammar you'd like to activate. For Ruby that would be `shift+ctrl+r`.

This pull request sets `shift+ctrl+z` for Zig.