### PR TITLE
Cleanup fmt command

### DIFF
--- a/Commands/Fmt.tmCommand
+++ b/Commands/Fmt.tmCommand
@@ -10,21 +10,11 @@
 # shellcheck source=/dev/null
 . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
-set -e 
+set -e
 
-PATH=/opt/local/bin:/usr/local/bin:/usr/local/zig/bin:$PATH
-        
-require_cmd zig
+require_cmd "${TM_ZIG:-zig}"
 
-tmpfile=$(mktemp "${TMPDIR:-/tmp/}zig-fmt.XXXXXX")
-cat - &gt; "$tmpfile"
-
-if ! error=$("${TM_ZIG:-zig}" fmt "$tmpfile" 2&gt;&amp;1);then
-    exit_show_tool_tip "${error//$tmpfile/$(basename "$TM_FILEPATH")}"
-fi
-
-cat "$tmpfile"
-rm "$tmpfile"
+(eval "${TM_ZIG:-zig} fmt --stdin") || exit_show_tool_tip
 </string>
 	<key>input</key>
 	<string>document</string>


### PR DESCRIPTION
Instead of creating a temporary file, we can just tell Zig to read the
input from stdin.