### PR TITLE
fix instant ci failures

### DIFF
--- a/.github/workflows/textmate.yaml
+++ b/.github/workflows/textmate.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          brew cask install textmate
+          brew install --cask textmate
           brew install coreutils zig
       - name: Textmate load success
         run: |


### PR DESCRIPTION
the current command used in the ci is outdated. according to the single google search i've done, this should fix the immediate ci failure.

as for how to fix the *later* ci failures i have no real idea.