### PR TITLE
Zig build cwd

### DIFF
--- a/Zig.py
+++ b/Zig.py
@@ -146,7 +146,10 @@ class ZigBuildCommand(sublime_plugin.WindowCommand, ProcessSink):
             return
 
         vars = self.window.extract_variables()
-        working_dir = vars.get('file_path', vars['folder'])
+        if build:
+            working_dir = vars['folder']
+        else:
+            working_dir = vars.get('file_path', vars['folder'])
 
         view = self.window.active_view()
         self.quiet = get_setting(view, 'zig.quiet', quiet)


### PR DESCRIPTION
Update the build step so that the cwd is always the project folder when using zig build / zig build run / zig build test. I was running into path problems running the build command otherwise.

When running commands against a file ie zig test <file> then it keeps the path assigned to that specific file.