### PR TITLE
Add `entity.name.type.zig` to `container_decl`.

### DIFF
--- a/Syntaxes/Zig.YAML-tmLanguage
+++ b/Syntaxes/Zig.YAML-tmLanguage
@@ -80,16 +80,16 @@ repository:
   container_decl:
     patterns:
       - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:union)\s*[(\{])'
-        name: entity.name.union.zig
+        name: entity.name.type.zig entity.name.union.zig
 
       - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:struct)\s*[(\{])'
-        name: entity.name.struct.zig
+        name: entity.name.type.zig entity.name.struct.zig
 
       - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:enum)\s*[(\{])'
-        name: entity.name.enum.zig
+        name: entity.name.type.zig entity.name.enum.zig
 
       - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:error)\s*[(\{])'
-        name: entity.name.error.zig
+        name: entity.name.type.zig entity.name.error.zig
 
       - match: '\b(error)(\.)([a-zA-Z_]\w*|@\".+\")'
         captures:

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -69,13 +69,13 @@ contexts:
       scope: constant.numeric.float.hexadecimal.zig
   container_decl:
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:union)\s*[(\{])'
-      scope: entity.name.union.zig
+      scope: entity.name.type.zig entity.name.union.zig
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:struct)\s*[(\{])'
-      scope: entity.name.struct.zig
+      scope: entity.name.type.zig entity.name.struct.zig
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:enum)\s*[(\{])'
-      scope: entity.name.enum.zig
+      scope: entity.name.type.zig entity.name.enum.zig
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:error)\s*[(\{])'
-      scope: entity.name.error.zig
+      scope: entity.name.type.zig entity.name.error.zig
     - match: '\b(error)(\.)([a-zA-Z_]\w*|@\".+\")'
       captures:
         1: storage.type.error.zig

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -276,10 +276,10 @@ contexts:
       scope: variable.constant.zig
 
     - match: '\b[_a-zA-Z][_a-zA-Z0-9]*_t\b'
-      scope: entity.name.type.zig
+      scope: storage.type.zig
 
     - match: '\b[A-Z][a-zA-Z0-9]*\b'
-      scope: entity.name.type.zig
+      scope: storage.type.zig
 
     - match: '\b[_a-zA-Z][_a-zA-Z0-9]*\b'
       scope: variable.zig

--- a/Syntaxes/Zig.tmLanguage
+++ b/Syntaxes/Zig.tmLanguage
@@ -194,25 +194,25 @@
 					<key>match</key>
 					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:union)\s*[(\{])</string>
 					<key>name</key>
-					<string>entity.name.union.zig</string>
+					<string>entity.name.type.zig entity.name.union.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:struct)\s*[(\{])</string>
 					<key>name</key>
-					<string>entity.name.struct.zig</string>
+					<string>entity.name.type.zig entity.name.struct.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:enum)\s*[(\{])</string>
 					<key>name</key>
-					<string>entity.name.enum.zig</string>
+					<string>entity.name.type.zig entity.name.enum.zig</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:error)\s*[(\{])</string>
 					<key>name</key>
-					<string>entity.name.error.zig</string>
+					<string>entity.name.type.zig entity.name.error.zig</string>
 				</dict>
 				<dict>
 					<key>captures</key>


### PR DESCRIPTION
This way, unions, structs, enums, and error declarations get properly marked as types so that "go to definition" works properly in sublime text.

I tried to follow the "Local Development" section in README.md, but just editing the `Zig.YAML-tmLanguage` file and using PackageDev to convert it didn't update the `sublime-syntax` file, which is apparently what sublime text prefers if it finds one, ignoring the `tmLanguage` version. So I edited the `sublime-syntax` version manually until things worked as expected, and transferred my changes to the `YAML-tmLanguage` file. Then I invoked the PackageDev `Convert To ()...` command but that only produced a `tmLanguage` file. The `tmLanguage.json` did not get updated. At that point, I was too confused by all this, being quite new to all this, so I figured I'd just get a PR going and ask for guidance.

Fixes #64 