### PR TITLE
Zig.py: fix result_file_regex

### DIFF
--- a/Zig.py
+++ b/Zig.py
@@ -158,7 +158,7 @@ class ZigBuildCommand(sublime_plugin.WindowCommand, ProcessSink):
             settings = self.panel.settings()
             settings.set(
                 'result_file_regex',
-                r'^(?:.\/)(\S.*):(\d*):(\d*): (?:[^:]*): (.*)$'
+                r'^(?:.\/)?(\S.*):(\d*):(\d*): (?:[^:]*): (.*)$'
             )
             settings.set(
                 'result_line_regex',


### PR DESCRIPTION
- make leading '.' optional
- before this, a leading '.' was required by this regex. this made parsing
  of error all error messages fail which don't have a leading '.'. as a
  result, i had never been able to see the build system's inline error
  messages.
- tested with zig version 0.10.0-dev.3838+77f31ebbb (Aug 31 2022)