### PR TITLE
Fix symbol list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,38 @@
 Zig Language
 ============
 
-Syntax highlighting for [Zig](http://ziglang.org/).
+Syntax highlighting for [Zig](http://ziglang.org/)
+for [Sublime Text](sublimetext.com/) editor.
+Use [Package control](https://packagecontrol.io) to install this.
 
-This repository serves both as the grammar for
-[github/linguist](https://github.com/github/linguist) (Github's site wide
-syntax highlighting) and as a standalone Sublime Text package.
+The two syntaxes
+----------------
 
-The source of truth is `Zig.YAML-tmLanguage`. This file is read by linguist
-directly and used as the source to compile to `Zig.tmLanguage` using
-[PackageDev](https://github.com/SublimeText/PackageDev) from within Sublime. Do
-not edit `Zig.tmLanguage` directly.
+Sublime Text 3 and above uses the `.sublime-syntax` file.
+This is the one you should edit to improve Sublime Text support.
+See [official docs](http://www.sublimetext.com/docs/3/syntax.html)
 
-Installation
+This repository also contains a `.tmLanguage` syntax for old versions of Sublime Text or TextMate.
+This file is also used by **Github's syntax highlighting**:
+[Github Linguist](https://github.com/github/linguist).
+
+
+Sublime text Installation
 -----------
 
-Use [Package control](https://packagecontrol.io).
+Use [Package control](https://packagecontrol.io) to install this.
 
-Or add `Zig.tmLanguage` to the packages directory. On OSX This is usually
-
-```
-~/Library/Application\ Support/Sublime\ Text\ 3/Packages/
-```
-
-But to find the path on your machine go to `Preferences > Browse Packages` from
-within Sublime Text.
 
 TextMate Installation
 ---------------------
 
-This language is also compatible with TextMate's `.tmBundle` format. To install in TextMate clone or download this repository. Then rename the repository directory to `Zig.tmBundle` and double-click it to install it into TextMate. However, see [Zig.tmbundle](https://github.com/ziglang/Zig.tmbundle) for dedicated TextMate support.
+The `Zig.tmLanguage` is also compatible with TextMate. 
+To install in TextMate clone or download this repository. 
+Then rename the repository directory to `Zig.tmBundle` and double-click it to install it into TextMate. 
+However, see [Zig.tmbundle](https://github.com/ziglang/Zig.tmbundle) for dedicated TextMate support.
 
 Local Development
 -----------------
-
-Install https://github.com/SublimeText/PackageDev.
 
 Clone or copy this repository to your local Sublime Text folder. e.g.
 
@@ -42,11 +40,21 @@ Clone or copy this repository to your local Sublime Text folder. e.g.
 git clone https://github.com/ziglang/sublime-zig-language.git "/Users/$USER/Library/Application Support/Sublime Text 3/Packages/Zig Language"
 ```
 
-Edit the YAML entry and use the `Convert (YAML, JSON, PList) to...` command
-to generate the other entries. Sublime Text will automatically reload the plugin, showing changes in the build system, syntax highlighting, etc.
+For working on ST3+ support, you can edit the `.sublime-syntax` directly.
+But installing [PackageDev](https://packagecontrol.io/packages/PackageDev)
+will provide some syntax highlighting.
+You can run the tests in [syntax_test.zig](./Syntaxes/syntax_test.zig)
+with the "Syntax Tests" builtin build system.
+Sublime Text will automatically reload the syntax on save.
+If you have a big Zig project open this can make your CPU spin while Sublime reindex everything.
 
 
-On Linux, this is located under `~/.config/sublime-text-3/`.
+For working on the old `.tmLanguage` syntax, work on the `Zig.YAML-tmLanguage` file.
+**Important** Github Linguist's source of truth is `Zig.YAML-tmLanguage`. 
+Work on `Zig.YAML-tmLanguage` the use PackageDev command: `Convert (YAML, JSON, PList) to...`
+to generate the `.tmLanguage`.
+Sublime Text should also automatically reload the plugin, but doesn't have unit tests for `tmLanguage`.
+
 
 Build System
 ------------

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -87,13 +87,13 @@ contexts:
       scope: constant.numeric.float.hexadecimal.zig
   container_decl:
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:union)\s*[(\{])'
-      scope: entity.name.union.zig
+      scope: entity.name.class.union.zig
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:struct)\s*[(\{])'
-      scope: entity.name.struct.zig
+      scope: entity.name.class.struct.zig
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:extern|packed)?\b\s*(?:enum)\s*[(\{])'
-      scope: entity.name.enum.zig
+      scope: entity.name.class.enum.zig
     - match: '\b(?!\d)([a-zA-Z_]\w*|@\".+\")?(?=\s*=\s*(?:error)\s*[(\{])'
-      scope: entity.name.error.zig
+      scope: entity.name.class.error.zig
     - match: '\b(error)(\.)([a-zA-Z_]\w*|@\".+\")'
       captures:
         1: storage.type.error.zig
@@ -117,7 +117,7 @@ contexts:
         - include: main
   function_call:
     - match: '\b([a-zA-Z_]\w*|@\".+\")(?=\s*\()'
-      scope: variable.function.zig
+      scope: meta.function-call.zig variable.function.zig
   function_def:
     - match: '\b(fn)\s+([a-zA-Z_]\w*|@\".+\")(\()'
       captures:

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -191,6 +191,9 @@ contexts:
       scope: keyword.operator.zig
     - match: '((?:(?:\+|-|\*)%?|/|%|<<|>>|&|\|(?=[^\|])|\^)=)'
       scope: keyword.operator.assignment.zig
+    # The => is for switch expression, I'm not sure this is the best scope.
+    - match: '=>'
+      scope: keyword.operator.assignment.zig
     - match: (==|(?:!|>|<)=?)
       scope: keyword.operator.logical.zig
     - match: '='

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -7,7 +7,25 @@ file_extensions:
 scope: source.zig
 contexts:
   main:
-    - include: dummy_main
+    - include: label
+    - include: function_type
+    - include: punctuation
+    - include: storage_modifier
+    - include: container_decl
+    - include: constants
+    - include: comments
+    - include: strings
+    - include: test
+    - include: storage
+    - include: keywords
+    - include: operators
+    - include: support
+    - include: field_decl
+    - include: block
+    - include: function_def
+    - include: function_call
+    - include: enum_literal
+    - include: variables
   block:
     - match: '([a-zA-Z_][\w.]*|@\".+\")?\s*(\{)'
       captures:
@@ -18,7 +36,7 @@ contexts:
           captures:
             1: punctuation.section.braces.end.zig
           pop: true
-        - include: dummy_main
+        - include: main
   character_escapes:
     - match: \\n
       scope: constant.character.escape.newline.zig
@@ -81,25 +99,6 @@ contexts:
         1: storage.type.error.zig
         2: punctuation.accessor.zig
         3: entity.name.error.zig
-  dummy_main:
-    - include: label
-    - include: function_type
-    - include: punctuation
-    - include: storage_modifier
-    - include: container_decl
-    - include: constants
-    - include: comments
-    - include: strings
-    - include: storage
-    - include: keywords
-    - include: operators
-    - include: support
-    - include: field_decl
-    - include: block
-    - include: function_def
-    - include: function_call
-    - include: enum_literal
-    - include: variables
   enum_literal:
     - match: '(^|\s+)(\.(?:[a-zA-Z_]\w*\b|@\"[^\"]*\"))(?!\(|\s*=[^=>])'
       scope: constant.language.enum
@@ -115,7 +114,7 @@ contexts:
             2: punctuation.separator.zig
             3: keyword.operator.assignment.zig
           pop: true
-        - include: dummy_main
+        - include: main
   function_call:
     - match: '\b([a-zA-Z_]\w*|@\".+\")(?=\s*\()'
       scope: variable.function.zig
@@ -133,7 +132,7 @@ contexts:
         - match: '\)'
           scope: punctuation.section.parens.end.zig
           set: function_def_after_params
-        - include: dummy_main
+        - include: main
   function_def_after_params:
     # TODO: be more precise here
     - match: '\s*([a-zA-Z_][\w.]*|@\".+\")?(!)?\s*(?:([a-zA-Z_][\w.]*|@\".+\")\b(?!\s*\())?'
@@ -159,7 +158,7 @@ contexts:
         - match: '\)'
           scope: punctuation.section.parens.end.zig
           set: function_type_after_params
-        - include: dummy_main
+        - include: main
   function_type_after_params:
     # TODO: Can we merge with function_def_after_params ? It seems similar.
     - match: '\s*([a-zA-Z_][\w.]*|@\".+\")?\s*(!)?\s*([a-zA-Z_][\w.]*|@\".+\")'
@@ -217,7 +216,7 @@ contexts:
             2: punctuation.separator.zig
             3: punctuation.section.parens.end.zig
           pop: true
-        - include: dummy_main
+        - include: main
         - match: '([a-zA-Z_][\w.]*|@\".+\")'
           scope: storage.type.zig
   punctuation:
@@ -286,3 +285,10 @@ contexts:
     - match: '\b[_a-zA-Z][_a-zA-Z0-9]*\b'
       scope: variable.zig
 
+  test:
+    - match: \b(test)\b\s+(\")(.*)(\")
+      captures:
+        0: entity.name.function.test.zig
+        1: storage.type.zig keyword.declaration.test.zig
+        2: punctuation.string.start.zig
+        4: punctuation.string.end.zig

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -98,7 +98,7 @@ contexts:
       captures:
         1: storage.type.error.zig
         2: punctuation.accessor.zig
-        3: entity.name.error.zig
+        3: constant.other.error.zig
   enum_literal:
     - match: '(^|\s+)(\.(?:[a-zA-Z_]\w*\b|@\"[^\"]*\"))(?!\(|\s*=[^=>])'
       scope: constant.language.enum

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -190,12 +190,14 @@ contexts:
   operators:
     - match: \b!\b
       scope: keyword.operator.zig
+    - match: '((?:(?:\+|-|\*)%?|/|%|<<|>>|&|\|(?=[^\|])|\^)=)'
+      scope: keyword.operator.assignment.zig
     - match: (==|(?:!|>|<)=?)
       scope: keyword.operator.logical.zig
+    - match: '='
+      scope: keyword.operator.assignment.zig
     - match: \b(and|or)\b
       scope: keyword.operator.word.zig
-    - match: '((?:(?:\+|-|\*)\%?|/|%|<<|>>|&|\|(?=[^\|])|\^)?=)'
-      scope: keyword.operator.assignment.zig
     - match: ((?:\+|-|\*)\%?|/(?!/)|%)
       scope: keyword.operator.arithmetic.zig
     - match: '(<<|>>|&(?=[a-zA-Z_]|@\")|\|(?=[^\|])|\^|~)'

--- a/Syntaxes/Zig.sublime-syntax
+++ b/Syntaxes/Zig.sublime-syntax
@@ -121,7 +121,7 @@ contexts:
   function_def:
     - match: '\b(fn)\s+([a-zA-Z_]\w*|@\".+\")(\()'
       captures:
-        1: storage.type.function.zig
+        1: keyword.declaration.function.zig
         2: entity.name.function
         3: punctuation.section.parens.begin.zig
       push:
@@ -147,7 +147,7 @@ contexts:
   function_type:
     - match: \b(fn)\s*(\()
       captures:
-        1: storage.type.function.zig
+        1: keyword.declaration.function.zig
         2: punctuation.section.parens.begin.zig
       push:
         - meta_content_scope: meta.function.parameters.zig
@@ -234,19 +234,19 @@ contexts:
   storage:
     - match: '\b(anyframe)\b\s*(->)?\s*(?:([a-zA-Z_][\w.]*|@\".+\")\b(?!\s*\())?'
       captures:
-        1: storage.type.zig
+        1: keyword.declaration.anyframe.zig
         2: keyword.operator.zig
-        3: storage.type.zig
+        3: keyword.declaration.zig
     - match: \btest\b
-      scope: storage.type.test.zig
+      scope: keyword.declaration.test.zig
     - match: \bstruct\b
-      scope: storage.type.struct.zig
+      scope: keyword.declaration.struct.zig
     - match: \benum\b
-      scope: storage.type.enum.zig
+      scope: keyword.declaration.enum.zig
     - match: \bunion\b
-      scope: storage.type.union.zig
+      scope: keyword.declaration.union.zig
     - match: \berror\b
-      scope: storage.type.error.zig
+      scope: keyword.declaration.error.zig
   storage_modifier:
     - match: \b(const|var|extern|packed|export|pub|noalias|inline|noinline|comptime|volatile|align|linksection|threadlocal|allowzero)\b
       scope: storage.modifier.zig
@@ -280,10 +280,10 @@ contexts:
       scope: variable.constant.zig
 
     - match: '\b[_a-zA-Z][_a-zA-Z0-9]*_t\b'
-      scope: entity.name.type.zig
+      scope: storage.type.zig
 
     - match: '\b[A-Z][a-zA-Z0-9]*\b'
-      scope: entity.name.type.zig
+      scope: storage.type.zig
 
     - match: '\b[_a-zA-Z][_a-zA-Z0-9]*\b'
       scope: variable.zig
@@ -292,6 +292,6 @@ contexts:
     - match: \b(test)\b\s+(\")(.*)(\")
       captures:
         0: entity.name.function.test.zig
-        1: storage.type.zig keyword.declaration.test.zig
+        1: keyword.declaration.test.zig
         2: punctuation.string.start.zig
         4: punctuation.string.end.zig

--- a/Syntaxes/syntax_test.zig
+++ b/Syntaxes/syntax_test.zig
@@ -133,7 +133,7 @@ a %= b
 a << b
 //^^ keyword.operator.logical.zig
 a <<= b
-//^^^ keyword.operator.logical.zig
+//^^^ keyword.operator.assignment.zig
 
 a & b
 a &= b

--- a/Syntaxes/syntax_test.zig
+++ b/Syntaxes/syntax_test.zig
@@ -283,7 +283,7 @@ errdefer |err| std.debug.assert(err == error.Overflow);
 //                                  ^^ keyword.operator.logical.zig
 //                                     ^^^^^ storage.type.error.zig
 //                                          ^ punctuation.accessor.zig
-//                                           ^^^^^^^^ entity.name.error.zig
+//                                           ^^^^^^^^ constant.other.error.zig
 //                                                   ^ punctuation.section.parens.end.zig
 //                                                    ^ punctuation.terminator.zig
 

--- a/Syntaxes/syntax_test.zig
+++ b/Syntaxes/syntax_test.zig
@@ -527,8 +527,7 @@ test "enum literals" {
     const result = switch (color) {
         .Auto => false,
 //      ^^^^^ constant.language.enum
-//            ^ keyword.operator.assignment.zig
-//             ^ keyword.operator.logical.zig
+//            ^^ keyword.operator.assignment.zig
 //               ^^^^^ constant.language.zig
         .On => true,
 //      ^^^ constant.language.enum

--- a/Syntaxes/syntax_test.zig
+++ b/Syntaxes/syntax_test.zig
@@ -180,8 +180,8 @@ a.*
 a || b
 
     test "tests" {
-//  ^^^^ storage.type.test.zig
-//       ^^^^^^^ string.quoted.double.zig
+//  ^^^^ storage.type.zig keyword.declaration.test.zig
+//  ^^^^^^^^^^^^ entity.name.function.test.zig
 //               ^ punctuation.section.braces.begin.zig
     }
 //  ^ punctuation.section.braces.end.zig

--- a/Syntaxes/syntax_test.zig
+++ b/Syntaxes/syntax_test.zig
@@ -13,7 +13,7 @@ const std = @import("std");
 
 pub fn main() !void {
 //^ storage.modifier.zig
-//  ^^ storage.type.function.zig
+//  ^^ keyword.declaration.function.zig
 //     ^^^^ entity.name.function
 //         ^ punctuation.section.parens.begin.zig
 //          ^ punctuation.section.parens.end.zig
@@ -55,7 +55,7 @@ asd {
 }
 
    fn dump(
-// ^^ storage.type.function.zig
+// ^^ keyword.declaration.function.zig
 //    ^^^^ entity.name.function
 //        ^ punctuation.section.parens.begin.zig
     value: var.asda.ad.asd,
@@ -180,7 +180,7 @@ a.*
 a || b
 
     test "tests" {
-//  ^^^^ storage.type.zig keyword.declaration.test.zig
+//  ^^^^ keyword.declaration.test.zig
 //  ^^^^^^^^^^^^ entity.name.function.test.zig
 //               ^ punctuation.section.braces.begin.zig
     }
@@ -254,7 +254,7 @@ const \\ adsjfaf23n9
 const v = fn(aas, 2342, 23) as;
 
 fn foo(a:as) i32 {
-// <- storage.type.function.zig
+// <- keyword.declaration.function.zig
 // ^^^ entity.name.function
 //    ^ punctuation.section.parens.begin.zig
 //     ^ variable.parameter.zig
@@ -312,7 +312,7 @@ test "strings" {
     '💩';
 }
    fn(i13i,Foo) Bar;
-// ^^ storage.type.function.zig
+// ^^ keyword.declaration.function.zig
 //   ^ punctuation.section.parens.begin.zig
 //    ^^^^ meta.function.parameters.zig storage.type.zig
 //        ^ meta.function.parameters.zig punctuation.separator.zig
@@ -441,21 +441,21 @@ pub fn asBytes(ptr: var) asdsa!AsBytesReturnType(@typeOf(ptr)) {
 pub const LARGE_INTEGER = extern struct {
 // <- storage.modifier.zig
 //  ^^^^^ storage.modifier.zig
-//        ^^^^^^^^^^^^^ entity.name.struct.zig
+//        ^^^^^^^^^^^^^ entity.name.class.struct.zig
 //                      ^ keyword.operator.assignment.zig
 //                        ^^^^^^ storage.modifier.zig
-//                               ^^^^^^ storage.type.struct.zig
+//                               ^^^^^^ keyword.declaration.struct.zig
 //                                      ^ punctuation.section.braces.begin.zig
     _u2: extern struct {
 //  ^^^ variable.other.member.zig
 //     ^ punctuation.separator.zig
 //       ^^^^^^ storage.modifier.zig
-//              ^^^^^^ storage.type.struct.zig
+//              ^^^^^^ keyword.declaration.struct.zig
 //                     ^ punctuation.section.braces.begin.zig
         LowPart: fn(a, b, c)d,
 //      ^^^^^^^ variable.other.member.zig
 //             ^ punctuation.separator.zig
-//               ^^ storage.type.function.zig
+//               ^^ keyword.declaration.function.zig
 //                 ^ punctuation.section.parens.begin.zig
 //                  ^ meta.function.parameters.zig storage.type.zig
 //                   ^ meta.function.parameters.zig punctuation.separator.zig
@@ -481,10 +481,10 @@ pub const LARGE_INTEGER = extern struct {
 
 pub const GUID = extern struct {
 //  ^^^^^ storage.modifier.zig
-//        ^^^^ entity.name.struct.zig
+//        ^^^^ entity.name.class.struct.zig
 //             ^ keyword.operator.assignment.zig
 //               ^^^^^^ storage.modifier.zig
-//                      ^^^^^^ storage.type.struct.zig
+//                      ^^^^^^ keyword.declaration.struct.zig
 //                             ^ punctuation.section.braces.begin.zig
     Data1: c_ulong,
 //  ^^^^^ variable.other.member.zig
@@ -501,7 +501,7 @@ pub const GUID = extern struct {
 
 pub async fn function() Error!ReturnType {
 //  ^^^^^ keyword.control.async.zig
-//        ^^ storage.type.function.zig
+//        ^^ keyword.declaration.function.zig
 //           ^^^^^^^^ entity.name.function
 }
 

--- a/Syntaxes/syntax_test.zig
+++ b/Syntaxes/syntax_test.zig
@@ -179,6 +179,13 @@ a.*
 
 a || b
 
+    test "tests" {
+//  ^^^^ storage.type.test.zig
+//       ^^^^^^^ string.quoted.double.zig
+//               ^ punctuation.section.braces.begin.zig
+    }
+//  ^ punctuation.section.braces.end.zig
+
 test "numbers" {
     123
 //  ^^^ constant.numeric.integer.zig


### PR DESCRIPTION
* mark function calls as such 
* make sure we have an index entry for enum, union #64 
* usage of type isn't a type definition #64 
* rename a few "storage.type" into "keyword.declaration" (for `fn`, `test`, ... )
* update readme to talk about the two different syntaxes